### PR TITLE
Add property marketplace contract and React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # Hackaton20025
+
+Este proyecto incluye un smart contract en Solidity para el manejo de ventas y alquileres de propiedades y una aplicación React que permite a los usuarios conectarse con MetaMask y publicar sus propiedades.
+
+## Smart Contract
+
+- **contracts/PropertyMarketplace.sol**: contrato que permite listar propiedades, comprarlas o rentarlas.
+- Usa Hardhat para compilar y ejecutar pruebas.
+
+### Comandos principales
+
+```bash
+npm install
+npm run compile
+npm test
+```
+
+## Frontend
+
+La carpeta `frontend` contiene una app React sencilla que interactúa con el contrato. Después de desplegar el contrato, coloque su dirección en `frontend/src/App.js` en la variable `contractAddress`.
+
+### Comandos frontend
+
+```bash
+cd frontend
+npm install
+npm start
+```

--- a/contracts/PropertyMarketplace.sol
+++ b/contracts/PropertyMarketplace.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract PropertyMarketplace {
+    uint public propertyCount;
+
+    struct Property {
+        uint id;
+        address payable owner;
+        string uri;
+        uint price;
+        bool forSale;
+        bool forRent;
+        bool rented;
+    }
+
+    mapping(uint => Property) public properties;
+
+    event PropertyListed(uint id, address owner, string uri, uint price, bool forSale, bool forRent);
+    event PropertyPurchased(uint id, address buyer);
+    event PropertyRented(uint id, address renter);
+
+    function listProperty(string memory uri, uint price, bool forSale, bool forRent) external {
+        require(forSale || forRent, "Must be for sale or rent");
+        propertyCount++;
+        properties[propertyCount] = Property(propertyCount, payable(msg.sender), uri, price, forSale, forRent, false);
+        emit PropertyListed(propertyCount, msg.sender, uri, price, forSale, forRent);
+    }
+
+    function buyProperty(uint id) external payable {
+        Property storage prop = properties[id];
+        require(prop.owner != address(0), "Property not found");
+        require(prop.forSale, "Not for sale");
+        require(msg.value == prop.price, "Incorrect price");
+
+        address payable seller = prop.owner;
+        prop.owner = payable(msg.sender);
+        prop.forSale = false;
+        seller.transfer(msg.value);
+
+        emit PropertyPurchased(id, msg.sender);
+    }
+
+    function rentProperty(uint id) external payable {
+        Property storage prop = properties[id];
+        require(prop.owner != address(0), "Property not found");
+        require(prop.forRent, "Not for rent");
+        require(!prop.rented, "Already rented");
+        require(msg.value == prop.price, "Incorrect rent");
+
+        prop.owner.transfer(msg.value);
+        prop.rented = true;
+
+        emit PropertyRented(id, msg.sender);
+    }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "ethers": "^5.7.2"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --watchAll=false"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Property DApp</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { ethers } from 'ethers';
+import PropertyMarketplace from '../artifacts/contracts/PropertyMarketplace.sol/PropertyMarketplace.json';
+
+const contractAddress = '0xYourContractAddress'; // replace after deployment
+
+function App() {
+  const [account, setAccount] = useState(null);
+  const [uri, setUri] = useState('');
+  const [price, setPrice] = useState('');
+
+  const connect = async () => {
+    if (!window.ethereum) {
+      alert('Please install MetaMask');
+      return;
+    }
+    const [acc] = await window.ethereum.request({ method: 'eth_requestAccounts' });
+    setAccount(acc);
+  };
+
+  const listProperty = async () => {
+    if (!uri || !price) return;
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const signer = provider.getSigner();
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
+    const tx = await contract.listProperty(uri, ethers.utils.parseEther(price), true, false);
+    await tx.wait();
+    setUri('');
+    setPrice('');
+  };
+
+  return (
+    <div>
+      {!account && <button onClick={connect}>Connect Wallet</button>}
+      {account && (
+        <div>
+          <input placeholder="Property URI" value={uri} onChange={e => setUri(e.target.value)} />
+          <input placeholder="Price in ETH" value={price} onChange={e => setPrice(e.target.value)} />
+          <button onClick={listProperty}>List Property for Sale</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,11 @@
+require('@nomicfoundation/hardhat-toolbox');
+
+module.exports = {
+  solidity: '0.8.20',
+  paths: {
+    sources: './contracts',
+    tests: './test',
+    cache: './cache',
+    artifacts: './artifacts'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "hackaton20025",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "compile": "hardhat compile",
+    "test": "hardhat test"
+  },
+  "devDependencies": {
+    "hardhat": "^2.19.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0"
+  }
+}

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -1,0 +1,15 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('PropertyMarketplace', function () {
+  it('should list a property', async function () {
+    const Marketplace = await ethers.getContractFactory('PropertyMarketplace');
+    const marketplace = await Marketplace.deploy();
+    await marketplace.deployed();
+
+    await marketplace.listProperty('ipfs://uri', ethers.utils.parseEther('1'), true, false);
+    const prop = await marketplace.properties(1);
+    expect(prop.owner).to.not.equal(ethers.constants.AddressZero);
+    expect(prop.price).to.equal(ethers.utils.parseEther('1'));
+  });
+});


### PR DESCRIPTION
## Summary
- add PropertyMarketplace solidity contract with listing, buying, and renting
- scaffold React dapp for MetaMask users to list properties

## Testing
- `npm test` *(fails: hardhat: not found)*
- `cd frontend && npm test` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e0d71e908333b1a1f9fa167a0e3e