### PR TITLE
feat(frontend): add tailwind UI with property slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+frontend/node_modules/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "ethers": "^5.7.2"
+    "ethers": "^5.7.2",
+    "tailwindcss": "^3.3.3",
+    "postcss": "^8.4.24",
+    "autoprefixer": "^10.4.14"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { ethers } from 'ethers';
 
 import PropertyMarketplace from './PropertyMarketplace.json';
-
+import PropertySlider from './components/PropertySlider';
 
 const contractAddress = '0xYourContractAddress'; // replace after deployment
 
@@ -31,16 +31,72 @@ function App() {
     setPrice('');
   };
 
+  const properties = [
+    {
+      id: 1,
+      title: 'Modern Apartment',
+      image: 'https://via.placeholder.com/800x400?text=Property+1',
+      price: '100 ETH',
+    },
+    {
+      id: 2,
+      title: 'Cozy House',
+      image: 'https://via.placeholder.com/800x400?text=Property+2',
+      price: '80 ETH',
+    },
+    {
+      id: 3,
+      title: 'Beach Villa',
+      image: 'https://via.placeholder.com/800x400?text=Property+3',
+      price: '200 ETH',
+    },
+  ];
+
   return (
-    <div>
-      {!account && <button onClick={connect}>Connect Wallet</button>}
+    <div className="min-h-screen bg-gray-100 p-4">
+      <header className="max-w-4xl mx-auto py-6">
+        <h1 className="text-3xl font-bold text-center mb-4">Property Marketplace</h1>
+        {!account && (
+          <div className="text-center">
+            <button
+              onClick={connect}
+              className="px-4 py-2 bg-blue-600 text-white rounded"
+            >
+              Connect Wallet
+            </button>
+          </div>
+        )}
+      </header>
+
       {account && (
-        <div>
-          <input placeholder="Property URI" value={uri} onChange={e => setUri(e.target.value)} />
-          <input placeholder="Price in ETH" value={price} onChange={e => setPrice(e.target.value)} />
-          <button onClick={listProperty}>List Property for Sale</button>
+        <div className="max-w-4xl mx-auto bg-white p-4 rounded shadow mb-8">
+          <div className="flex flex-col gap-4">
+            <input
+              className="border p-2 rounded"
+              placeholder="Property URI"
+              value={uri}
+              onChange={e => setUri(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Price in ETH"
+              value={price}
+              onChange={e => setPrice(e.target.value)}
+            />
+            <button
+              onClick={listProperty}
+              className="self-start px-4 py-2 bg-green-600 text-white rounded"
+            >
+              List Property for Sale
+            </button>
+          </div>
         </div>
       )}
+
+      <section className="max-w-4xl mx-auto">
+        <h2 className="text-2xl font-semibold mb-4">Featured Properties</h2>
+        <PropertySlider properties={properties} />
+      </section>
     </div>
   );
 }

--- a/frontend/src/components/PropertySlider.js
+++ b/frontend/src/components/PropertySlider.js
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+function PropertySlider({ properties }) {
+  const [index, setIndex] = useState(0);
+  const next = () => setIndex((index + 1) % properties.length);
+  const prev = () => setIndex((index - 1 + properties.length) % properties.length);
+
+  return (
+    <div className="relative w-full max-w-2xl mx-auto">
+      <div className="overflow-hidden rounded-lg">
+        <div
+          className="flex transition-transform duration-500"
+          style={{ transform: `translateX(-${index * 100}%)` }}
+        >
+          {properties.map(p => (
+            <div key={p.id} className="flex-shrink-0 w-full relative">
+              <img
+                src={p.image}
+                alt={p.title}
+                className="w-full h-64 object-cover"
+              />
+              <div className="absolute bottom-0 left-0 right-0 bg-black bg-opacity-50 text-white p-4">
+                <h3 className="text-lg font-semibold">{p.title}</h3>
+                <p className="text-sm">{p.price}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+      <button
+        onClick={prev}
+        className="absolute top-1/2 left-0 transform -translate-y-1/2 bg-white bg-opacity-75 hover:bg-opacity-100 p-2"
+      >
+        ‹
+      </button>
+      <button
+        onClick={next}
+        className="absolute top-1/2 right-0 transform -translate-y-1/2 bg-white bg-opacity-75 hover:bg-opacity-100 p-2"
+      >
+        ›
+      </button>
+    </div>
+  );
+}
+
+export default PropertySlider;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import './index.css';
 
 const container = document.getElementById('root');
 const root = createRoot(container);

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Summary
- integrate Tailwind CSS in the frontend and add configuration files
- add a property slider component with sample listings and apply professional styling
- ignore node_modules with a new .gitignore

## Testing
- `npm test` *(fails: Couldn't download compiler version list. Please check your internet connection and try again.)*
- `cd frontend && npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e77633288333b40a9f4d1127061f