### PR TITLE
Add detailed metadata fields to properties

### DIFF
--- a/contracts/PropertyMarketplace.sol
+++ b/contracts/PropertyMarketplace.sol
@@ -26,8 +26,14 @@ contract PropertyMarketplace {
     struct Property {
         uint id;
         address payable owner;
-        string uri;
-        uint price;
+        string titulo;
+        string descripcion;
+        uint precioUSDT;
+        uint seniaUSDT;
+        string fotoSlider;
+        string fotosMini;
+        string fotoAvatar;
+        string url;
         bool forSale;
         bool forRent;
         bool rented;
@@ -36,7 +42,7 @@ contract PropertyMarketplace {
     mapping(uint => Property) public properties;
     mapping(address => KYC) public kycs;
 
-    event PropertyListed(uint id, address owner, string uri, uint price, bool forSale, bool forRent);
+    event PropertyListed(uint id, address owner, string titulo, uint precioUSDT, bool forSale, bool forRent);
     event PropertyPurchased(uint id, address buyer);
     event PropertyRented(uint id, address renter);
 
@@ -119,18 +125,50 @@ contract PropertyMarketplace {
         );
     }
 
-    function listProperty(string memory uri, uint price, bool forSale, bool forRent) external onlyVerified {
+    function listProperty(
+        string memory titulo,
+        string memory descripcion,
+        uint precioUSDT,
+        uint seniaUSDT,
+        string memory fotoSlider,
+        string memory fotosMini,
+        string memory fotoAvatar,
+        string memory url,
+        bool forSale,
+        bool forRent
+    ) external onlyVerified {
+        require(bytes(titulo).length > 0, "Title required");
+        require(bytes(descripcion).length > 0, "Description required");
+        require(precioUSDT > 0, "Price required");
+        require(bytes(fotoSlider).length > 0, "Slider photo required");
+        require(bytes(fotosMini).length > 0, "Mini photos required");
+        require(bytes(fotoAvatar).length > 0, "Avatar photo required");
+        require(bytes(url).length > 0, "URL required");
         require(forSale || forRent, "Must be for sale or rent");
         propertyCount++;
-        properties[propertyCount] = Property(propertyCount, payable(msg.sender), uri, price, forSale, forRent, false);
-        emit PropertyListed(propertyCount, msg.sender, uri, price, forSale, forRent);
+        properties[propertyCount] = Property(
+            propertyCount,
+            payable(msg.sender),
+            titulo,
+            descripcion,
+            precioUSDT,
+            seniaUSDT,
+            fotoSlider,
+            fotosMini,
+            fotoAvatar,
+            url,
+            forSale,
+            forRent,
+            false
+        );
+        emit PropertyListed(propertyCount, msg.sender, titulo, precioUSDT, forSale, forRent);
     }
 
     function buyProperty(uint id) external payable onlyVerified {
         Property storage prop = properties[id];
         require(prop.owner != address(0), "Property not found");
         require(prop.forSale, "Not for sale");
-        require(msg.value == prop.price, "Incorrect price");
+        require(msg.value == prop.precioUSDT, "Incorrect price");
 
         address payable seller = prop.owner;
         prop.owner = payable(msg.sender);
@@ -145,7 +183,7 @@ contract PropertyMarketplace {
         require(prop.owner != address(0), "Property not found");
         require(prop.forRent, "Not for rent");
         require(!prop.rented, "Already rented");
-        require(msg.value == prop.price, "Incorrect rent");
+        require(msg.value == prop.precioUSDT, "Incorrect rent");
 
         prop.owner.transfer(msg.value);
         prop.rented = true;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -10,8 +10,14 @@ const contractAddress = '0xYourContractAddress'; // replace after deployment
 
 function App() {
   const [account, setAccount] = useState(null);
-  const [uri, setUri] = useState('');
-  const [price, setPrice] = useState('');
+  const [titulo, setTitulo] = useState('');
+  const [descripcion, setDescripcion] = useState('');
+  const [precioUSDT, setPrecioUSDT] = useState('');
+  const [seniaUSDT, setSeniaUSDT] = useState('');
+  const [fotoSlider, setFotoSlider] = useState('');
+  const [fotosMini, setFotosMini] = useState('');
+  const [fotoAvatar, setFotoAvatar] = useState('');
+  const [url, setUrl] = useState('');
 
   const connect = async () => {
     if (!window.ethereum) {
@@ -27,14 +33,31 @@ function App() {
   };
 
   const listProperty = async () => {
-    if (!uri || !price) return;
+    if (!titulo || !descripcion || !precioUSDT || !fotoSlider || !fotosMini || !fotoAvatar || !url) return;
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const signer = provider.getSigner();
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
-    const tx = await contract.listProperty(uri, ethers.utils.parseEther(price), true, false);
+    const tx = await contract.listProperty(
+      titulo,
+      descripcion,
+      ethers.utils.parseEther(precioUSDT),
+      ethers.utils.parseEther(seniaUSDT || '0'),
+      fotoSlider,
+      fotosMini,
+      fotoAvatar,
+      url,
+      true,
+      false
+    );
     await tx.wait();
-    setUri('');
-    setPrice('');
+    setTitulo('');
+    setDescripcion('');
+    setPrecioUSDT('');
+    setSeniaUSDT('');
+    setFotoSlider('');
+    setFotosMini('');
+    setFotoAvatar('');
+    setUrl('');
   };
 
   const properties = [
@@ -69,15 +92,51 @@ function App() {
           <div className="flex flex-col gap-4">
             <input
               className="border p-2 rounded"
-              placeholder="Property URI"
-              value={uri}
-              onChange={e => setUri(e.target.value)}
+              placeholder="Titulo"
+              value={titulo}
+              onChange={e => setTitulo(e.target.value)}
             />
             <input
               className="border p-2 rounded"
-              placeholder="Price in ETH"
-              value={price}
-              onChange={e => setPrice(e.target.value)}
+              placeholder="Descripcion"
+              value={descripcion}
+              onChange={e => setDescripcion(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Precio en ETH"
+              value={precioUSDT}
+              onChange={e => setPrecioUSDT(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Seña en ETH"
+              value={seniaUSDT}
+              onChange={e => setSeniaUSDT(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Foto Slider URI"
+              value={fotoSlider}
+              onChange={e => setFotoSlider(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Fotos Mini URI"
+              value={fotosMini}
+              onChange={e => setFotosMini(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Foto Avatar URI"
+              value={fotoAvatar}
+              onChange={e => setFotoAvatar(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="URL"
+              value={url}
+              onChange={e => setUrl(e.target.value)}
             />
             <button
               onClick={listProperty}

--- a/frontend/src/PropertyMarketplace.json
+++ b/frontend/src/PropertyMarketplace.json
@@ -2,8 +2,14 @@
   "abi": [
     {
       "inputs": [
-        {"internalType": "string", "name": "uri", "type": "string"},
-        {"internalType": "uint256", "name": "price", "type": "uint256"},
+        {"internalType": "string", "name": "titulo", "type": "string"},
+        {"internalType": "string", "name": "descripcion", "type": "string"},
+        {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
+        {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
+        {"internalType": "string", "name": "fotoSlider", "type": "string"},
+        {"internalType": "string", "name": "fotosMini", "type": "string"},
+        {"internalType": "string", "name": "fotoAvatar", "type": "string"},
+        {"internalType": "string", "name": "url", "type": "string"},
         {"internalType": "bool", "name": "forSale", "type": "bool"},
         {"internalType": "bool", "name": "forRent", "type": "bool"}
       ],
@@ -114,8 +120,14 @@
       "outputs": [
         {"internalType": "uint256", "name": "id", "type": "uint256"},
         {"internalType": "address", "name": "owner", "type": "address"},
-        {"internalType": "string", "name": "uri", "type": "string"},
-        {"internalType": "uint256", "name": "price", "type": "uint256"},
+        {"internalType": "string", "name": "titulo", "type": "string"},
+        {"internalType": "string", "name": "descripcion", "type": "string"},
+        {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
+        {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
+        {"internalType": "string", "name": "fotoSlider", "type": "string"},
+        {"internalType": "string", "name": "fotosMini", "type": "string"},
+        {"internalType": "string", "name": "fotoAvatar", "type": "string"},
+        {"internalType": "string", "name": "url", "type": "string"},
         {"internalType": "bool", "name": "forSale", "type": "bool"},
         {"internalType": "bool", "name": "forRent", "type": "bool"},
         {"internalType": "bool", "name": "rented", "type": "bool"}
@@ -137,8 +149,8 @@
       "inputs": [
         {"indexed": false, "internalType": "uint256", "name": "id", "type": "uint256"},
         {"indexed": false, "internalType": "address", "name": "owner", "type": "address"},
-        {"indexed": false, "internalType": "string", "name": "uri", "type": "string"},
-        {"indexed": false, "internalType": "uint256", "name": "price", "type": "uint256"},
+        {"indexed": false, "internalType": "string", "name": "titulo", "type": "string"},
+        {"indexed": false, "internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
         {"indexed": false, "internalType": "bool", "name": "forSale", "type": "bool"},
         {"indexed": false, "internalType": "bool", "name": "forRent", "type": "bool"}
       ],

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -9,7 +9,18 @@ describe('PropertyMarketplace', function () {
     await marketplace.deployed();
 
     await expect(
-      marketplace.connect(user).listProperty('ipfs://uri', ethers.utils.parseEther('1'), true, false)
+      marketplace.connect(user).listProperty(
+        'Titulo',
+        'Descripcion',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        true,
+        false
+      )
     ).to.be.revertedWith('Not verified');
 
     await marketplace
@@ -27,9 +38,23 @@ describe('PropertyMarketplace', function () {
         'A1234567'
       );
     await marketplace.verifyKYC(user.address);
-    await marketplace.connect(user).listProperty('ipfs://uri', ethers.utils.parseEther('1'), true, false);
+    await marketplace
+      .connect(user)
+      .listProperty(
+        'Titulo',
+        'Descripcion',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        true,
+        false
+      );
     const prop = await marketplace.properties(1);
     expect(prop.owner).to.equal(user.address);
+    expect(prop.titulo).to.equal('Titulo');
   });
 
   it('admin can cancel a sale', async function () {
@@ -53,7 +78,20 @@ describe('PropertyMarketplace', function () {
         'A1234567'
       );
     await marketplace.verifyKYC(user.address);
-    await marketplace.connect(user).listProperty('ipfs://uri', ethers.utils.parseEther('1'), true, false);
+    await marketplace
+      .connect(user)
+      .listProperty(
+        'Titulo',
+        'Descripcion',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        true,
+        false
+      );
     await marketplace.adminCancelSale(1);
     const prop = await marketplace.properties(1);
     expect(prop.forSale).to.equal(false);


### PR DESCRIPTION
## Summary
- expand `Property` struct with title, description, pricing and image fields
- require all new fields when listing and update frontend + ABI
- adjust unit tests for new `listProperty` signature

## Testing
- `npm run compile` *(fails: Couldn't download compiler version list)*
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c35dbe3eb48333a176263184e90d07