### PR TITLE
Integrate Privy wallet auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hackaton20025
 
-Este proyecto incluye un smart contract en Solidity para el manejo de ventas y alquileres de propiedades y una aplicación React que permite a los usuarios conectarse con MetaMask y publicar sus propiedades.
+Este proyecto incluye un smart contract en Solidity para el manejo de ventas y alquileres de propiedades y una aplicación React que permite a los usuarios autenticarse mediante [Privy](https://www.privy.io/) para crear o conectar wallets y publicar sus propiedades.
 
 ## Smart Contract
 
@@ -18,7 +18,13 @@ npm test
 ## Frontend
 
 
-La carpeta `frontend` contiene una app React sencilla que interactúa con el contrato. Después de desplegar el contrato, coloque su dirección en `frontend/src/App.js` en la variable `contractAddress` y asegúrese de que el ABI del contrato se encuentre en `frontend/src/PropertyMarketplace.json`.
+La carpeta `frontend` contiene una app React sencilla que interactúa con el contrato. Ahora utiliza Privy para manejar el inicio de sesión y la creación de wallets embebidas. Antes de ejecutar la aplicación, crea un archivo `.env` dentro de `frontend` con tu identificador de aplicación de Privy:
+
+```
+REACT_APP_PRIVY_APP_ID=tu_app_id
+```
+
+Después de desplegar el contrato, coloca su dirección en `frontend/src/App.js` en la variable `contractAddress` y asegúrate de que el ABI del contrato se encuentre en `frontend/src/PropertyMarketplace.json`.
 
 
 ### Comandos frontend

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_PRIVY_APP_ID=your_privy_app_id

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "ethers": "^5.7.2",
     "tailwindcss": "^3.3.3",
     "postcss": "^8.4.24",
-    "autoprefixer": "^10.4.14"
+    "autoprefixer": "^10.4.14",
+    "@privy-io/react-auth": "^1.53.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -12,7 +12,7 @@ function Navbar({ account, connect, disconnect }) {
               onClick={disconnect}
               className="px-3 py-1 bg-red-500 text-white rounded"
             >
-              Disconnect
+              Logout
             </button>
           </div>
         ) : (
@@ -20,7 +20,7 @@ function Navbar({ account, connect, disconnect }) {
             onClick={connect}
             className="px-3 py-1 bg-blue-600 text-white rounded"
           >
-            Connect Wallet
+            Login
           </button>
         )}
       </div>

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -2,7 +2,20 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { PrivyProvider } from '@privy-io/react-auth';
 
 const container = document.getElementById('root');
 const root = createRoot(container);
-root.render(<App />);
+const privyAppId = process.env.REACT_APP_PRIVY_APP_ID;
+
+root.render(
+  <PrivyProvider
+    appId={privyAppId}
+    config={{
+      loginMethods: ['email', 'wallet'],
+      embeddedWallets: { createOnLogin: 'users-without-wallets' },
+    }}
+  >
+    <App />
+  </PrivyProvider>
+);


### PR DESCRIPTION
## Summary
- add Privy React SDK for email and wallet login
- wrap app with PrivyProvider and expose login/logout
- document Privy setup and env vars

## Testing
- `npm test` (fails: Couldn't download compiler version list)
- `cd frontend && npm test` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68c35e4a75d083339b39a1ddbb8cf724