### PR TITLE
feat: add rental reservations with smart lock access codes

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { ethers } from 'ethers';
 
 import PropertyMarketplace from './PropertyMarketplace.json';
@@ -10,6 +10,7 @@ const contractAddress = '0xYourContractAddress'; // replace after deployment
 
 function App() {
   const [account, setAccount] = useState(null);
+  const [properties, setProperties] = useState([]);
   const [titulo, setTitulo] = useState('');
   const [descripcion, setDescripcion] = useState('');
   const [precioUSDT, setPrecioUSDT] = useState('');
@@ -31,6 +32,36 @@ function App() {
   const disconnect = () => {
     setAccount(null);
   };
+
+  const fetchProperties = async () => {
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, provider);
+    const count = await contract.propertyCount();
+    const props = [];
+    for (let i = 1; i <= count; i++) {
+      const p = await contract.properties(i);
+      props.push({
+        id: p.id.toNumber(),
+        titulo: p.titulo,
+        descripcion: p.descripcion,
+        precioWei: p.precioUSDT,
+        seniaWei: p.seniaUSDT,
+        precio: ethers.utils.formatEther(p.precioUSDT),
+        senia: ethers.utils.formatEther(p.seniaUSDT),
+        foto: p.fotoSlider,
+        forRent: p.forRent,
+        date: '',
+        code: ''
+      });
+    }
+    setProperties(props);
+  };
+
+  useEffect(() => {
+    if (account) {
+      fetchProperties();
+    }
+  }, [account]);
 
   const listProperty = async () => {
     if (!titulo || !descripcion || !precioUSDT || !fotoSlider || !fotosMini || !fotoAvatar || !url) return;
@@ -60,7 +91,41 @@ function App() {
     setUrl('');
   };
 
-  const properties = [
+  const handleDateChange = (id, value) => {
+    setProperties(props =>
+      props.map(p => (p.id === id ? { ...p, date: value } : p))
+    );
+  };
+
+  const reserve = async id => {
+    const prop = properties.find(p => p.id === id);
+    if (!prop || !prop.date) return;
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const signer = provider.getSigner();
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
+    const timestamp = Math.floor(new Date(prop.date).setHours(0, 0, 0, 0) / 1000);
+    const tx = await contract.reserveDate(id, timestamp, { value: prop.seniaWei });
+    await tx.wait();
+  };
+
+  const payRent = async id => {
+    const prop = properties.find(p => p.id === id);
+    if (!prop || !prop.date) return;
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const signer = provider.getSigner();
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
+    const timestamp = Math.floor(new Date(prop.date).setHours(0, 0, 0, 0) / 1000);
+    const value = prop.precioWei.sub(prop.seniaWei);
+    const tx = await contract.payRent(id, timestamp, { value });
+    const receipt = await tx.wait();
+    const event = receipt.events?.find(e => e.event === 'AccessCodeGenerated');
+    const code = event && event.args ? event.args.code : '';
+    setProperties(props =>
+      props.map(p => (p.id === id ? { ...p, code: code } : p))
+    );
+  };
+
+  const sliderProps = [
     {
       id: 1,
       title: 'Modern Apartment',
@@ -150,7 +215,46 @@ function App() {
 
       <section className="max-w-4xl mx-auto p-4">
         <h2 className="text-2xl font-semibold mb-4">Featured Properties</h2>
-        <PropertySlider properties={properties} />
+        <PropertySlider properties={sliderProps} />
+      </section>
+
+      <section className="max-w-4xl mx-auto p-4">
+        <h2 className="text-2xl font-semibold mb-4">Available Properties</h2>
+        {properties.map(p => (
+          <div key={p.id} className="bg-white p-4 rounded shadow mb-4">
+            <img src={p.foto} alt={p.titulo} className="w-full h-48 object-cover mb-2" />
+            <h3 className="text-xl font-semibold">{p.titulo}</h3>
+            <p className="text-sm mb-2">{p.descripcion}</p>
+            <p className="text-sm">Precio: {p.precio} ETH</p>
+            {p.forRent && (
+              <div className="mt-2 flex flex-col gap-2">
+                <input
+                  type="date"
+                  value={p.date}
+                  onChange={e => handleDateChange(p.id, e.target.value)}
+                  className="border p-2 rounded"
+                />
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => reserve(p.id)}
+                    className="px-4 py-2 bg-blue-600 text-white rounded"
+                  >
+                    Reservar ({p.senia} ETH)
+                  </button>
+                  <button
+                    onClick={() => payRent(p.id)}
+                    className="px-4 py-2 bg-green-600 text-white rounded"
+                  >
+                    Pagar Renta
+                  </button>
+                </div>
+                {p.code && (
+                  <p className="text-sm">Codigo de acceso: {p.code}</p>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
       </section>
     </div>
   );

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -96,4 +96,82 @@ describe('PropertyMarketplace', function () {
     const prop = await marketplace.properties(1);
     expect(prop.forSale).to.equal(false);
   });
+
+  it('allows reserving and paying rent with access code generation', async function () {
+    const [admin, owner, renter] = await ethers.getSigners();
+    const Marketplace = await ethers.getContractFactory('PropertyMarketplace');
+    const marketplace = await Marketplace.deploy();
+    await marketplace.deployed();
+
+    // Owner lists a property for rent
+    await marketplace
+      .connect(owner)
+      .submitKYC(
+        'Owner',
+        'Lister',
+        'owner@example.com',
+        '123 Main St',
+        'Metropolis',
+        'Wonderland',
+        '12345',
+        '555-0000',
+        'Passport',
+        'O1234567'
+      );
+    await marketplace.verifyKYC(owner.address);
+    await marketplace
+      .connect(owner)
+      .listProperty(
+        'Casa',
+        'Linda casa',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        false,
+        true
+      );
+
+    // Renter KYC
+    await marketplace
+      .connect(renter)
+      .submitKYC(
+        'Renter',
+        'User',
+        'renter@example.com',
+        '456 Side St',
+        'Gotham',
+        'Wonderland',
+        '67890',
+        '555-1111',
+        'Passport',
+        'R1234567'
+      );
+    await marketplace.verifyKYC(renter.address);
+
+    const day = 1700000000; // example day timestamp
+
+    // Reserve the day with deposit
+    await marketplace
+      .connect(renter)
+      .reserveDate(1, day, { value: ethers.utils.parseEther('0.1') });
+
+    expect(await marketplace.isDateAvailable(1, day)).to.equal(false);
+
+    await expect(
+      marketplace
+        .connect(renter)
+        .reserveDate(1, day, { value: ethers.utils.parseEther('0.1') })
+    ).to.be.revertedWith('Date reserved');
+
+    // Pay remaining amount and receive code
+    const tx = await marketplace
+      .connect(renter)
+      .payRent(1, day, { value: ethers.utils.parseEther('0.9') });
+    const receipt = await tx.wait();
+    const event = receipt.events.find((e) => e.event === 'AccessCodeGenerated');
+    expect(event.args.code).to.not.equal(ethers.constants.HashZero);
+  });
 });


### PR DESCRIPTION
## Summary
- add reservation tracking per property day with deposit, final payment, and access code
- expose availability checks and payment flow for rentals
- cover reservation flow with new tests
- add frontend to list contract properties and reserve rental dates

## Testing
- `npm test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c5826fb9b88333875c9160d9c81f06