### PR TITLE
Add configurable payment token, price, and sale pause

### DIFF
--- a/contracts/GovernanceToken.sol
+++ b/contracts/GovernanceToken.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface IERC20 {
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}
+
+contract GovernanceToken {
+    string public constant name = "Governance Token";
+    string public constant symbol = "GOV";
+    uint8 public constant decimals = 18;
+
+    uint256 public constant maxSupply = 21_000_000 * 10 ** 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    address public owner;
+    address public paymentToken;
+    uint256 public price; // price per token in smallest unit of payment token
+    bool public salePaused;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event PaymentTokenUpdated(address indexed newToken);
+    event PriceUpdated(uint256 newPrice);
+    event SalePaused(bool paused);
+
+    constructor(address _token, uint256 _price) {
+        owner = msg.sender;
+        paymentToken = _token;
+        price = _price;
+        totalSupply = maxSupply;
+        balanceOf[address(this)] = maxSupply;
+        uint256 creatorAmount = 1_000_000 * 10 ** 18;
+        _transfer(address(this), msg.sender, creatorAmount);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "not owner");
+        _;
+    }
+
+    function setPaymentToken(address _token) external onlyOwner {
+        paymentToken = _token;
+        emit PaymentTokenUpdated(_token);
+    }
+
+    function setPrice(uint256 _price) external onlyOwner {
+        price = _price;
+        emit PriceUpdated(_price);
+    }
+
+    function setSalePaused(bool _paused) external onlyOwner {
+        salePaused = _paused;
+        emit SalePaused(_paused);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "balance");
+        unchecked {
+            balanceOf[from] -= amount;
+            balanceOf[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+
+    // Buy tokens using the configured payment token. `amount` is the number of tokens without decimals
+    function buyTokens(uint256 amount) external {
+        require(!salePaused, "sale paused");
+        require(amount > 0, "amount 0");
+        uint256 tokenAmount = amount * 10 ** 18;
+        require(balanceOf[address(this)] >= tokenAmount, "insufficient tokens");
+        uint256 cost = amount * price;
+        require(IERC20(paymentToken).transferFrom(msg.sender, address(this), cost), "payment failed");
+        _transfer(address(this), msg.sender, tokenAmount);
+    }
+}
+

--- a/contracts/mocks/TestToken.sol
+++ b/contracts/mocks/TestToken.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// Simple ERC20 token with minting for testing purposes
+contract TestToken {
+    string public name;
+    string public symbol;
+    uint8 public constant decimals = 18;
+    uint256 public totalSupply;
+
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    constructor(string memory _name, string memory _symbol) {
+        name = _name;
+        symbol = _symbol;
+    }
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+        totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function _transfer(address from, address to, uint256 amount) internal {
+        require(balanceOf[from] >= amount, "balance");
+        unchecked {
+            balanceOf[from] -= amount;
+            balanceOf[to] += amount;
+        }
+        emit Transfer(from, to, amount);
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        _transfer(msg.sender, to, amount);
+        return true;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        if (allowed != type(uint256).max) {
+            allowance[from][msg.sender] = allowed - amount;
+        }
+        _transfer(from, to, amount);
+        return true;
+    }
+}
+

--- a/test/GovernanceToken.js
+++ b/test/GovernanceToken.js
@@ -1,0 +1,40 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('GovernanceToken', function () {
+  it('manages token sales with adjustable token, price and pause', async function () {
+    const [owner, buyer] = await ethers.getSigners();
+
+    const Token = await ethers.getContractFactory('TestToken');
+    const tokenA = await Token.deploy('TokenA', 'TKA');
+    const tokenB = await Token.deploy('TokenB', 'TKB');
+
+    await tokenA.mint(buyer.address, ethers.utils.parseUnits('1000', 18));
+    await tokenB.mint(buyer.address, ethers.utils.parseUnits('1000', 18));
+
+    const Gov = await ethers.getContractFactory('GovernanceToken');
+    const gov = await Gov.deploy(tokenA.address, ethers.utils.parseUnits('1', 18));
+
+    expect(await gov.totalSupply()).to.equal(ethers.utils.parseUnits('21000000', 18));
+    expect(await gov.balanceOf(owner.address)).to.equal(ethers.utils.parseUnits('1000000', 18));
+    expect(await gov.balanceOf(gov.address)).to.equal(ethers.utils.parseUnits('20000000', 18));
+
+    await tokenA.connect(buyer).approve(gov.address, ethers.utils.parseUnits('100', 18));
+    await gov.connect(buyer).buyTokens(100);
+    expect(await gov.balanceOf(buyer.address)).to.equal(ethers.utils.parseUnits('100', 18));
+
+    await gov.connect(owner).setSalePaused(true);
+    await expect(gov.connect(buyer).buyTokens(1)).to.be.revertedWith('sale paused');
+
+    await gov.connect(owner).setSalePaused(false);
+    await gov.connect(owner).setPrice(ethers.utils.parseUnits('2', 18));
+    await gov.connect(owner).setPaymentToken(tokenB.address);
+
+    await tokenB.connect(buyer).approve(gov.address, ethers.utils.parseUnits('200', 18));
+    await gov.connect(buyer).buyTokens(50);
+
+    expect(await gov.balanceOf(buyer.address)).to.equal(ethers.utils.parseUnits('150', 18));
+    expect(await tokenB.balanceOf(gov.address)).to.equal(ethers.utils.parseUnits('100', 18));
+  });
+});
+


### PR DESCRIPTION
## Summary
- Allow governance token admin to adjust payment token, token price, and pause or resume token sales
- Replace USDT mock with generic TestToken used in tests
- Extend tests to cover adjustable token sale features

## Testing
- `npm test` *(fails: HH502 Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c58657f66883338d040fc4385a3e3d