### PR TITLE
Prevent same-day property bookings

### DIFF
--- a/contracts/PropertyMarketplace.sol
+++ b/contracts/PropertyMarketplace.sol
@@ -213,6 +213,7 @@ contract PropertyMarketplace {
         Property storage prop = properties[id];
         require(prop.owner != address(0), "Property not found");
         require(prop.forRent, "Not for rent");
+        require(date >= block.timestamp + 1 days, "Same-day booking not allowed");
         require(isDateAvailable(id, date), "Date reserved");
         require(msg.value == prop.seniaUSDT, "Incorrect deposit");
 

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -174,4 +174,68 @@ describe('PropertyMarketplace', function () {
     const event = receipt.events.find((e) => e.event === 'AccessCodeGenerated');
     expect(event.args.code).to.not.equal(ethers.constants.HashZero);
   });
+
+  it('reverts when reserving for the same day', async function () {
+    const [admin, owner, renter] = await ethers.getSigners();
+    const Marketplace = await ethers.getContractFactory('PropertyMarketplace');
+    const marketplace = await Marketplace.deploy();
+    await marketplace.deployed();
+
+    // Owner lists a property for rent
+    await marketplace
+      .connect(owner)
+      .submitKYC(
+        'Owner',
+        'Lister',
+        'owner@example.com',
+        '123 Main St',
+        'Metropolis',
+        'Wonderland',
+        '12345',
+        '555-0000',
+        'Passport',
+        'O1234567'
+      );
+    await marketplace.verifyKYC(owner.address);
+    await marketplace
+      .connect(owner)
+      .listProperty(
+        'Casa',
+        'Linda casa',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        false,
+        true
+      );
+
+    // Renter KYC
+    await marketplace
+      .connect(renter)
+      .submitKYC(
+        'Renter',
+        'User',
+        'renter@example.com',
+        '456 Side St',
+        'Gotham',
+        'Wonderland',
+        '67890',
+        '555-1111',
+        'Passport',
+        'R1234567'
+      );
+    await marketplace.verifyKYC(renter.address);
+
+    const currentBlock = await ethers.provider.getBlock('latest');
+    const sameDay = currentBlock.timestamp + 3600; // 1 hour later, same day
+
+    await expect(
+      marketplace
+        .connect(renter)
+        .reserveDate(1, sameDay, { value: ethers.utils.parseEther('0.1') })
+    ).to.be.revertedWith('Same-day booking not allowed');
+  });
 });


### PR DESCRIPTION
## Summary
- enforce on-chain check that reservations must be at least one day ahead
- test rental flow rejects same-day reservations

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c58f0152488333a86676f22d420c1f