### PR TITLE
feat: add KYC and property management pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,6 +5,7 @@ import PropertyMarketplace from './PropertyMarketplace.json';
 import PropertySlider from './components/PropertySlider';
 import Navbar from './components/Navbar';
 import KYCForm from './components/KYCForm';
+import MyProperties from './components/MyProperties';
 
 const contractAddress = '0xYourContractAddress'; // replace after deployment
 
@@ -19,6 +20,7 @@ function App() {
   const [fotosMini, setFotosMini] = useState('');
   const [fotoAvatar, setFotoAvatar] = useState('');
   const [url, setUrl] = useState('');
+  const [page, setPage] = useState('home');
 
   const connect = async () => {
     if (!window.ethereum) {
@@ -148,11 +150,17 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gray-100">
-      <Navbar account={account} connect={connect} disconnect={disconnect} />
+      <Navbar account={account} connect={connect} disconnect={disconnect} setPage={setPage} />
 
-      {account && <KYCForm account={account} contractAddress={contractAddress} />}
+      {account && page === 'kyc' && (
+        <KYCForm account={account} contractAddress={contractAddress} />
+      )}
 
-      {account && (
+      {account && page === 'myProperties' && (
+        <MyProperties account={account} contractAddress={contractAddress} />
+      )}
+
+      {account && page === 'home' && (
         <div className="max-w-4xl mx-auto bg-white p-4 rounded shadow mb-8">
           <div className="flex flex-col gap-4">
             <input
@@ -213,6 +221,8 @@ function App() {
         </div>
       )}
 
+      {page === 'home' && (
+        <>
         <section className="max-w-4xl mx-auto p-4">
           <h2 className="text-2xl font-semibold mb-4">Featured Rentals</h2>
           <PropertySlider properties={sliderProps} />
@@ -256,6 +266,8 @@ function App() {
           </div>
         ))}
       </section>
+      </>
+      )}
     </div>
   );
 }

--- a/frontend/src/PropertyMarketplace.json
+++ b/frontend/src/PropertyMarketplace.json
@@ -2,70 +2,6 @@
   "abi": [
     {
       "inputs": [
-        {"internalType": "string", "name": "titulo", "type": "string"},
-        {"internalType": "string", "name": "descripcion", "type": "string"},
-        {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
-        {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
-        {"internalType": "string", "name": "fotoSlider", "type": "string"},
-        {"internalType": "string", "name": "fotosMini", "type": "string"},
-        {"internalType": "string", "name": "fotoAvatar", "type": "string"},
-        {"internalType": "string", "name": "url", "type": "string"},
-        {"internalType": "bool", "name": "forSale", "type": "bool"},
-        {"internalType": "bool", "name": "forRent", "type": "bool"}
-      ],
-      "name": "listProperty",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
-      ],
-      "name": "buyProperty",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
-      ],
-      "name": "rentProperty",
-      "outputs": [],
-      "stateMutability": "payable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"}
-      ],
-      "name": "adminCancelSale",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "uint256", "name": "id", "type": "uint256"},
-        {"internalType": "address", "name": "previousOwner", "type": "address"}
-      ],
-      "name": "adminCancelPurchase",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {"internalType": "address", "name": "newAdmin", "type": "address"}
-      ],
-      "name": "setAdmin",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
         {"internalType": "string", "name": "firstName", "type": "string"},
         {"internalType": "string", "name": "lastName", "type": "string"},
         {"internalType": "string", "name": "email", "type": "string"},
@@ -83,18 +19,14 @@
       "type": "function"
     },
     {
-      "inputs": [
-        {"internalType": "address", "name": "user", "type": "address"}
-      ],
+      "inputs": [{"internalType": "address", "name": "user", "type": "address"}],
       "name": "verifyKYC",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
     },
     {
-      "inputs": [
-        {"internalType": "address", "name": "user", "type": "address"}
-      ],
+      "inputs": [{"internalType": "address", "name": "user", "type": "address"}],
       "name": "getKYC",
       "outputs": [
         {"internalType": "string", "name": "", "type": "string"},
@@ -114,8 +46,72 @@
     },
     {
       "inputs": [
-        {"internalType": "uint256", "name": "", "type": "uint256"}
+        {"internalType": "string", "name": "titulo", "type": "string"},
+        {"internalType": "string", "name": "descripcion", "type": "string"},
+        {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
+        {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
+        {"internalType": "string", "name": "fotoSlider", "type": "string"},
+        {"internalType": "string", "name": "fotosMini", "type": "string"},
+        {"internalType": "string", "name": "fotoAvatar", "type": "string"},
+        {"internalType": "string", "name": "url", "type": "string"},
+        {"internalType": "bool", "name": "forSale", "type": "bool"},
+        {"internalType": "bool", "name": "forRent", "type": "bool"}
       ],
+      "name": "listProperty",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"},
+        {"internalType": "uint256", "name": "date", "type": "uint256"}
+      ],
+      "name": "reserveDate",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {"internalType": "uint256", "name": "id", "type": "uint256"},
+        {"internalType": "uint256", "name": "date", "type": "uint256"}
+      ],
+      "name": "payRent",
+      "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+      "name": "pauseProperty",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+      "name": "resumeProperty",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [{"internalType": "uint256", "name": "id", "type": "uint256"}],
+      "name": "removeProperty",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "propertyCount",
+      "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
       "name": "properties",
       "outputs": [
         {"internalType": "uint256", "name": "id", "type": "uint256"},
@@ -136,44 +132,11 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "propertyCount",
-      "outputs": [
-        {"internalType": "uint256", "name": "", "type": "uint256"}
-      ],
+      "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+      "name": "reservationCount",
+      "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
       "stateMutability": "view",
       "type": "function"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {"indexed": false, "internalType": "uint256", "name": "id", "type": "uint256"},
-        {"indexed": false, "internalType": "address", "name": "owner", "type": "address"},
-        {"indexed": false, "internalType": "string", "name": "titulo", "type": "string"},
-        {"indexed": false, "internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
-        {"indexed": false, "internalType": "bool", "name": "forSale", "type": "bool"},
-        {"indexed": false, "internalType": "bool", "name": "forRent", "type": "bool"}
-      ],
-      "name": "PropertyListed",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {"indexed": false, "internalType": "uint256", "name": "id", "type": "uint256"},
-        {"indexed": false, "internalType": "address", "name": "buyer", "type": "address"}
-      ],
-      "name": "PropertyPurchased",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {"indexed": false, "internalType": "uint256", "name": "id", "type": "uint256"},
-        {"indexed": false, "internalType": "address", "name": "renter", "type": "address"}
-      ],
-      "name": "PropertyRented",
-      "type": "event"
     }
   ]
 }

--- a/frontend/src/components/KYCForm.js
+++ b/frontend/src/components/KYCForm.js
@@ -94,12 +94,14 @@ function KYCForm({ account, contractAddress }) {
           <p><strong>ID Type:</strong> {formData.idType}</p>
           <p><strong>ID Number:</strong> {formData.idNumber}</p>
           <p><strong>Verified:</strong> {verified ? 'Yes' : 'Pending'}</p>
-          <button
-            onClick={handleEdit}
-            className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
-          >
-            Edit
-          </button>
+          {!verified && (
+            <button
+              onClick={handleEdit}
+              className="mt-2 px-4 py-2 bg-blue-600 text-white rounded"
+            >
+              Edit
+            </button>
+          )}
         </div>
       ) : (
         <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/frontend/src/components/MyProperties.js
+++ b/frontend/src/components/MyProperties.js
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react';
+import { ethers } from 'ethers';
+import PropertyMarketplace from '../PropertyMarketplace.json';
+
+function MyProperties({ account, contractAddress }) {
+  const [properties, setProperties] = useState([]);
+
+  const load = async () => {
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, provider);
+    const count = await contract.propertyCount();
+    const props = [];
+    for (let i = 1; i <= count; i++) {
+      const p = await contract.properties(i);
+      if (p.owner.toLowerCase() === account.toLowerCase()) {
+        const reservations = await contract.reservationCount(i);
+        props.push({
+          id: p.id.toNumber(),
+          titulo: p.titulo,
+          forRent: p.forRent,
+          reservations: reservations.toNumber(),
+        });
+      }
+    }
+    setProperties(props);
+  };
+
+  useEffect(() => {
+    if (account) load();
+  }, [account]);
+
+  const remove = async (id) => {
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const signer = provider.getSigner();
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
+    const tx = await contract.removeProperty(id);
+    await tx.wait();
+    load();
+  };
+
+  const toggleRent = async (id, forRent) => {
+    const provider = new ethers.providers.Web3Provider(window.ethereum);
+    const signer = provider.getSigner();
+    const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
+    const tx = await (forRent ? contract.pauseProperty(id) : contract.resumeProperty(id));
+    await tx.wait();
+    load();
+  };
+
+  if (!account) return null;
+
+  return (
+    <div className="max-w-4xl mx-auto p-4">
+      <h2 className="text-2xl font-semibold mb-4">My Properties</h2>
+      {properties.map((p) => (
+        <div key={p.id} className="bg-white p-4 rounded shadow mb-4">
+          <h3 className="text-xl font-semibold">{p.titulo}</h3>
+          <div className="flex gap-2 mt-2">
+            <button
+              onClick={() => toggleRent(p.id, p.forRent)}
+              className="px-3 py-1 bg-yellow-500 text-white rounded"
+            >
+              {p.forRent ? 'Pause' : 'Resume'}
+            </button>
+            <button
+              onClick={() => remove(p.id)}
+              disabled={p.reservations > 0}
+              className={`px-3 py-1 ${p.reservations > 0 ? 'bg-gray-300' : 'bg-red-500'} text-white rounded`}
+            >
+              Delete
+            </button>
+          </div>
+          {p.reservations > 0 && (
+            <p className="text-sm text-red-600 mt-2">Active reservations exist</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default MyProperties;

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,12 +1,25 @@
 import React from 'react';
 
-function Navbar({ account, connect, disconnect }) {
+function Navbar({ account, connect, disconnect, setPage }) {
   return (
     <nav className="bg-white shadow mb-8">
       <div className="max-w-4xl mx-auto p-4 flex justify-between items-center">
-        <div>
-          <h1 className="text-xl font-bold">Airbnbit.com</h1>
-          <p className="text-sm text-gray-600">Alquiler de propiedades en blockchain</p>
+        <div className="flex items-center gap-4">
+          <div>
+            <h1 className="text-xl font-bold">Airbnbit.com</h1>
+            <p className="text-sm text-gray-600">Alquiler de propiedades en blockchain</p>
+          </div>
+          <button onClick={() => setPage('home')} className="text-blue-600">
+            Home
+          </button>
+          <button onClick={() => setPage('kyc')} className="text-blue-600">
+            KYC
+          </button>
+          {account && (
+            <button onClick={() => setPage('myProperties')} className="text-blue-600">
+              My Properties
+            </button>
+          )}
         </div>
         {account ? (
           <div className="flex items-center gap-4">

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -174,4 +174,115 @@ describe('PropertyMarketplace', function () {
     const event = receipt.events.find((e) => e.event === 'AccessCodeGenerated');
     expect(event.args.code).to.not.equal(ethers.constants.HashZero);
   });
+
+  it('owner can pause, resume, and remove property without active reservations', async function () {
+    const [admin, owner] = await ethers.getSigners();
+    const Marketplace = await ethers.getContractFactory('PropertyMarketplace');
+    const marketplace = await Marketplace.deploy();
+    await marketplace.deployed();
+
+    await marketplace
+      .connect(owner)
+      .submitKYC(
+        'Owner',
+        'Lister',
+        'owner@example.com',
+        '123 Main St',
+        'Metropolis',
+        'Wonderland',
+        '12345',
+        '555-0000',
+        'Passport',
+        'O1234567'
+      );
+    await marketplace.verifyKYC(owner.address);
+    await marketplace
+      .connect(owner)
+      .listProperty(
+        'Casa',
+        'Linda casa',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        false,
+        true
+      );
+
+    await marketplace.connect(owner).pauseProperty(1);
+    let prop = await marketplace.properties(1);
+    expect(prop.forRent).to.equal(false);
+
+    await marketplace.connect(owner).resumeProperty(1);
+    prop = await marketplace.properties(1);
+    expect(prop.forRent).to.equal(true);
+
+    await marketplace.connect(owner).removeProperty(1);
+    prop = await marketplace.properties(1);
+    expect(prop.owner).to.equal(ethers.constants.AddressZero);
+  });
+
+  it('cannot remove property with active reservations', async function () {
+    const [admin, owner, renter] = await ethers.getSigners();
+    const Marketplace = await ethers.getContractFactory('PropertyMarketplace');
+    const marketplace = await Marketplace.deploy();
+    await marketplace.deployed();
+
+    await marketplace
+      .connect(owner)
+      .submitKYC(
+        'Owner',
+        'Lister',
+        'owner@example.com',
+        '123 Main St',
+        'Metropolis',
+        'Wonderland',
+        '12345',
+        '555-0000',
+        'Passport',
+        'O1234567'
+      );
+    await marketplace.verifyKYC(owner.address);
+    await marketplace
+      .connect(owner)
+      .listProperty(
+        'Casa',
+        'Linda casa',
+        ethers.utils.parseEther('1'),
+        ethers.utils.parseEther('0.1'),
+        'slider',
+        'mini',
+        'avatar',
+        'url',
+        false,
+        true
+      );
+
+    await marketplace
+      .connect(renter)
+      .submitKYC(
+        'Renter',
+        'User',
+        'renter@example.com',
+        '456 Side St',
+        'Gotham',
+        'Wonderland',
+        '67890',
+        '555-1111',
+        'Passport',
+        'R1234567'
+      );
+    await marketplace.verifyKYC(renter.address);
+
+    const day = 1700000000;
+    await marketplace
+      .connect(renter)
+      .reserveDate(1, day, { value: ethers.utils.parseEther('0.1') });
+
+    await expect(
+      marketplace.connect(owner).removeProperty(1)
+    ).to.be.revertedWith('Active reservations');
+  });
 });


### PR DESCRIPTION
## Summary
- allow pausing, resuming and deleting properties when they have no active reservations
- show KYC info on a dedicated page and disable edits after verification
- add a My Properties page to manage listings, with navbar links for navigation

## Testing
- `npm test` *(fails: Couldn't download compiler version list)*
- `npm test` (frontend) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c58fe3e44483339ef6337872ff999d