### PR TITLE
Add property location search and separate creation page

### DIFF
--- a/contracts/PropertyMarketplace.sol
+++ b/contracts/PropertyMarketplace.sol
@@ -28,6 +28,8 @@ contract PropertyMarketplace {
         address payable owner;
         string titulo;
         string descripcion;
+        string city;
+        string postalCode;
         uint precioUSDT;
         uint seniaUSDT;
         string fotoSlider;
@@ -143,6 +145,8 @@ contract PropertyMarketplace {
     function listProperty(
         string memory titulo,
         string memory descripcion,
+        string memory city,
+        string memory postalCode,
         uint precioUSDT,
         uint seniaUSDT,
         string memory fotoSlider,
@@ -154,6 +158,8 @@ contract PropertyMarketplace {
     ) external onlyVerified {
         require(bytes(titulo).length > 0, "Title required");
         require(bytes(descripcion).length > 0, "Description required");
+        require(bytes(city).length > 0, "City required");
+        require(bytes(postalCode).length > 0, "Postal code required");
         require(precioUSDT > 0, "Price required");
         require(bytes(fotoSlider).length > 0, "Slider photo required");
         require(bytes(fotosMini).length > 0, "Mini photos required");
@@ -166,6 +172,8 @@ contract PropertyMarketplace {
             payable(msg.sender),
             titulo,
             descripcion,
+            city,
+            postalCode,
             precioUSDT,
             seniaUSDT,
             fotoSlider,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,6 +14,8 @@ function App() {
   const [properties, setProperties] = useState([]);
   const [titulo, setTitulo] = useState('');
   const [descripcion, setDescripcion] = useState('');
+  const [city, setCity] = useState('');
+  const [postalCode, setPostalCode] = useState('');
   const [precioUSDT, setPrecioUSDT] = useState('');
   const [seniaUSDT, setSeniaUSDT] = useState('');
   const [fotoSlider, setFotoSlider] = useState('');
@@ -21,6 +23,9 @@ function App() {
   const [fotoAvatar, setFotoAvatar] = useState('');
   const [url, setUrl] = useState('');
   const [page, setPage] = useState('home');
+  const [searchCity, setSearchCity] = useState('');
+  const [searchPostal, setSearchPostal] = useState('');
+  const [searchName, setSearchName] = useState('');
 
   const connect = async () => {
     if (!window.ethereum) {
@@ -46,6 +51,8 @@ function App() {
         id: p.id.toNumber(),
         titulo: p.titulo,
         descripcion: p.descripcion,
+        city: p.city,
+        postalCode: p.postalCode,
         precioWei: p.precioUSDT,
         seniaWei: p.seniaUSDT,
         precio: ethers.utils.formatEther(p.precioUSDT),
@@ -66,25 +73,29 @@ function App() {
   }, [account]);
 
   const listProperty = async () => {
-    if (!titulo || !descripcion || !precioUSDT || !fotoSlider || !fotosMini || !fotoAvatar || !url) return;
+    if (!titulo || !descripcion || !city || !postalCode || !precioUSDT || !fotoSlider || !fotosMini || !fotoAvatar || !url) return;
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const signer = provider.getSigner();
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
-      const tx = await contract.listProperty(
-        titulo,
-        descripcion,
-        ethers.utils.parseEther(precioUSDT),
-        ethers.utils.parseEther(seniaUSDT || '0'),
-        fotoSlider,
-        fotosMini,
-        fotoAvatar,
-        url,
-        false,
-        true
-      );
+    const tx = await contract.listProperty(
+      titulo,
+      descripcion,
+      city,
+      postalCode,
+      ethers.utils.parseEther(precioUSDT),
+      ethers.utils.parseEther(seniaUSDT || '0'),
+      fotoSlider,
+      fotosMini,
+      fotoAvatar,
+      url,
+      false,
+      true
+    );
     await tx.wait();
     setTitulo('');
     setDescripcion('');
+    setCity('');
+    setPostalCode('');
     setPrecioUSDT('');
     setSeniaUSDT('');
     setFotoSlider('');
@@ -148,6 +159,13 @@ function App() {
     },
   ];
 
+  const filtered = properties.filter(
+    p =>
+      (!searchCity || p.city.toLowerCase().includes(searchCity.toLowerCase())) &&
+      (!searchPostal || p.postalCode.includes(searchPostal)) &&
+      (!searchName || p.titulo.toLowerCase().includes(searchName.toLowerCase()))
+  );
+
   return (
     <div className="min-h-screen bg-gray-100">
       <Navbar account={account} connect={connect} disconnect={disconnect} setPage={setPage} />
@@ -160,7 +178,7 @@ function App() {
         <MyProperties account={account} contractAddress={contractAddress} />
       )}
 
-      {account && page === 'home' && (
+      {account && page === 'create' && (
         <div className="max-w-4xl mx-auto bg-white p-4 rounded shadow mb-8">
           <div className="flex flex-col gap-4">
             <input
@@ -174,6 +192,18 @@ function App() {
               placeholder="Descripcion"
               value={descripcion}
               onChange={e => setDescripcion(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Ciudad"
+              value={city}
+              onChange={e => setCity(e.target.value)}
+            />
+            <input
+              className="border p-2 rounded"
+              placeholder="Codigo Postal"
+              value={postalCode}
+              onChange={e => setPostalCode(e.target.value)}
             />
             <input
               className="border p-2 rounded"
@@ -223,50 +253,71 @@ function App() {
 
       {page === 'home' && (
         <>
-        <section className="max-w-4xl mx-auto p-4">
-          <h2 className="text-2xl font-semibold mb-4">Featured Rentals</h2>
-          <PropertySlider properties={sliderProps} />
-        </section>
+          <section className="max-w-4xl mx-auto p-4">
+            <h2 className="text-2xl font-semibold mb-4">Featured Rentals</h2>
+            <PropertySlider properties={sliderProps} />
+          </section>
 
-        <section className="max-w-4xl mx-auto p-4">
-          <h2 className="text-2xl font-semibold mb-4">Available Rentals</h2>
-          {properties.map(p => (
-          <div key={p.id} className="bg-white p-4 rounded shadow mb-4">
-            <img src={p.foto} alt={p.titulo} className="w-full h-48 object-cover mb-2" />
-            <h3 className="text-xl font-semibold">{p.titulo}</h3>
-            <p className="text-sm mb-2">{p.descripcion}</p>
-            <p className="text-sm">Precio: {p.precio} ETH</p>
-            {p.forRent && (
-              <div className="mt-2 flex flex-col gap-2">
-                <input
-                  type="date"
-                  value={p.date}
-                  onChange={e => handleDateChange(p.id, e.target.value)}
-                  className="border p-2 rounded"
-                />
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => reserve(p.id)}
-                    className="px-4 py-2 bg-blue-600 text-white rounded"
-                  >
-                    Reservar ({p.senia} ETH)
-                  </button>
-                  <button
-                    onClick={() => payRent(p.id)}
-                    className="px-4 py-2 bg-green-600 text-white rounded"
-                  >
-                    Pagar Renta
-                  </button>
-                </div>
-                {p.code && (
-                  <p className="text-sm">Codigo de acceso: {p.code}</p>
+          <section className="max-w-4xl mx-auto p-4">
+            <h2 className="text-2xl font-semibold mb-4">Available Rentals</h2>
+            <div className="flex flex-col md:flex-row gap-2 mb-4">
+              <input
+                className="border p-2 rounded"
+                placeholder="Ciudad"
+                value={searchCity}
+                onChange={e => setSearchCity(e.target.value)}
+              />
+              <input
+                className="border p-2 rounded"
+                placeholder="Codigo Postal"
+                value={searchPostal}
+                onChange={e => setSearchPostal(e.target.value)}
+              />
+              <input
+                className="border p-2 rounded"
+                placeholder="Nombre"
+                value={searchName}
+                onChange={e => setSearchName(e.target.value)}
+              />
+            </div>
+            {filtered.map(p => (
+              <div key={p.id} className="bg-white p-4 rounded shadow mb-4">
+                <img src={p.foto} alt={p.titulo} className="w-full h-48 object-cover mb-2" />
+                <h3 className="text-xl font-semibold">{p.titulo}</h3>
+                <p className="text-sm mb-2">{p.descripcion}</p>
+                <p className="text-sm">{p.city} - {p.postalCode}</p>
+                <p className="text-sm">Precio: {p.precio} ETH</p>
+                {p.forRent && (
+                  <div className="mt-2 flex flex-col gap-2">
+                    <input
+                      type="date"
+                      value={p.date}
+                      onChange={e => handleDateChange(p.id, e.target.value)}
+                      className="border p-2 rounded"
+                    />
+                    <div className="flex gap-2">
+                      <button
+                        onClick={() => reserve(p.id)}
+                        className="px-4 py-2 bg-blue-600 text-white rounded"
+                      >
+                        Reservar ({p.senia} ETH)
+                      </button>
+                      <button
+                        onClick={() => payRent(p.id)}
+                        className="px-4 py-2 bg-green-600 text-white rounded"
+                      >
+                        Pagar Renta
+                      </button>
+                    </div>
+                    {p.code && (
+                      <p className="text-sm">Codigo de acceso: {p.code}</p>
+                    )}
+                  </div>
                 )}
               </div>
-            )}
-          </div>
-        ))}
-      </section>
-      </>
+            ))}
+          </section>
+        </>
       )}
     </div>
   );

--- a/frontend/src/PropertyMarketplace.json
+++ b/frontend/src/PropertyMarketplace.json
@@ -48,6 +48,8 @@
       "inputs": [
         {"internalType": "string", "name": "titulo", "type": "string"},
         {"internalType": "string", "name": "descripcion", "type": "string"},
+        {"internalType": "string", "name": "city", "type": "string"},
+        {"internalType": "string", "name": "postalCode", "type": "string"},
         {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
         {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
         {"internalType": "string", "name": "fotoSlider", "type": "string"},
@@ -118,6 +120,8 @@
         {"internalType": "address", "name": "owner", "type": "address"},
         {"internalType": "string", "name": "titulo", "type": "string"},
         {"internalType": "string", "name": "descripcion", "type": "string"},
+        {"internalType": "string", "name": "city", "type": "string"},
+        {"internalType": "string", "name": "postalCode", "type": "string"},
         {"internalType": "uint256", "name": "precioUSDT", "type": "uint256"},
         {"internalType": "uint256", "name": "seniaUSDT", "type": "uint256"},
         {"internalType": "string", "name": "fotoSlider", "type": "string"},

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -20,6 +20,11 @@ function Navbar({ account, connect, disconnect, setPage }) {
               My Properties
             </button>
           )}
+          {account && (
+            <button onClick={() => setPage('create')} className="text-blue-600">
+              Create Property
+            </button>
+          )}
         </div>
         {account ? (
           <div className="flex items-center gap-4">

--- a/test/PropertyMarketplace.js
+++ b/test/PropertyMarketplace.js
@@ -12,6 +12,8 @@ describe('PropertyMarketplace', function () {
       marketplace.connect(user).listProperty(
         'Titulo',
         'Descripcion',
+        'Metropolis',
+        '12345',
         ethers.utils.parseEther('1'),
         ethers.utils.parseEther('0.1'),
         'slider',
@@ -43,6 +45,8 @@ describe('PropertyMarketplace', function () {
       .listProperty(
         'Titulo',
         'Descripcion',
+        'Metropolis',
+        '12345',
         ethers.utils.parseEther('1'),
         ethers.utils.parseEther('0.1'),
         'slider',
@@ -83,6 +87,8 @@ describe('PropertyMarketplace', function () {
       .listProperty(
         'Titulo',
         'Descripcion',
+        'Metropolis',
+        '12345',
         ethers.utils.parseEther('1'),
         ethers.utils.parseEther('0.1'),
         'slider',
@@ -124,6 +130,8 @@ describe('PropertyMarketplace', function () {
       .listProperty(
         'Casa',
         'Linda casa',
+        'Metropolis',
+        '12345',
         ethers.utils.parseEther('1'),
         ethers.utils.parseEther('0.1'),
         'slider',
@@ -201,6 +209,8 @@ describe('PropertyMarketplace', function () {
       .listProperty(
         'Casa',
         'Linda casa',
+        'Metropolis',
+        '12345',
         ethers.utils.parseEther('1'),
         ethers.utils.parseEther('0.1'),
         'slider',


### PR DESCRIPTION
## Summary
- track city and postal code in `Property` and listing API
- add dedicated page for creating properties
- support filtering properties by city, postal code, or name on home page

## Testing
- `npm run compile` *(fails: Couldn't download compiler version list)*
- `npm test` *(fails: Couldn't download compiler version list)*

------
https://chatgpt.com/codex/tasks/task_e_68c592586a4c83339febc18e7e824334