### PR TITLE
Validate contract address to avoid ENS errors

### DIFF
--- a/frontend/src/components/KYCForm.js
+++ b/frontend/src/components/KYCForm.js
@@ -20,6 +20,7 @@ function KYCForm({ account, contractAddress }) {
 
   useEffect(() => {
     const fetchKYC = async () => {
+      if (!ethers.utils.isAddress(contractAddress)) return;
       const provider = new ethers.providers.Web3Provider(window.ethereum);
       const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, provider);
       const [firstName, lastName, email, street, city, country, postalCode, phone, idType, idNumber, isVerified] =
@@ -52,6 +53,10 @@ function KYCForm({ account, contractAddress }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!ethers.utils.isAddress(contractAddress)) {
+      console.error('Invalid contract address');
+      return;
+    }
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const signer = provider.getSigner();
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);

--- a/frontend/src/components/MyProperties.js
+++ b/frontend/src/components/MyProperties.js
@@ -6,6 +6,7 @@ function MyProperties({ account, contractAddress }) {
   const [properties, setProperties] = useState([]);
 
   const load = async () => {
+    if (!ethers.utils.isAddress(contractAddress)) return;
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, provider);
     const count = await contract.propertyCount();
@@ -30,6 +31,7 @@ function MyProperties({ account, contractAddress }) {
   }, [account]);
 
   const remove = async (id) => {
+    if (!ethers.utils.isAddress(contractAddress)) return;
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const signer = provider.getSigner();
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);
@@ -39,6 +41,7 @@ function MyProperties({ account, contractAddress }) {
   };
 
   const toggleRent = async (id, forRent) => {
+    if (!ethers.utils.isAddress(contractAddress)) return;
     const provider = new ethers.providers.Web3Provider(window.ethereum);
     const signer = provider.getSigner();
     const contract = new ethers.Contract(contractAddress, PropertyMarketplace.abi, signer);


### PR DESCRIPTION
## Summary
- load contract address from env and validate before instantiating contracts
- skip contract interactions when address is missing to prevent ENS resolution errors
- guard KYC and property components against invalid addresses

## Testing
- `npm test` *(fails: Couldn't download compiler version list (HH502))*

------
https://chatgpt.com/codex/tasks/task_e_68c763b16d548333bbde7125cd3f0157