### PR TITLE
Add residency calendar with Google Calendar export

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { ethers } from 'ethers';
 
 import ActivityRegistry from './ActivityRegistry.json';
 import Navbar from './components/Navbar';
+import ActivityCalendar from './components/ActivityCalendar';
 import { translations, residencyActivities as residencyCatalog, localeMap } from './translations';
 
 const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
@@ -50,6 +51,45 @@ function App() {
     [language]
   );
   const locale = useMemo(() => localeMap[language] || localeMap.en, [language]);
+  const calendarMonths = useMemo(
+    () => [
+      { year: 2024, month: 9, label: text.calendar.months.october },
+      { year: 2024, month: 10, label: text.calendar.months.november }
+    ],
+    [text.calendar.months]
+  );
+  const seasonalEvents = useMemo(() => {
+    const createDate = (month, day) => new Date(Date.UTC(2024, month, day));
+    return [
+      {
+        id: 'october-climb',
+        title: text.calendar.events.octoberClimb.title,
+        shortLabel: text.calendar.events.octoberClimb.shortLabel,
+        description: text.calendar.events.octoberClimb.description,
+        type: 'climb',
+        start: createDate(9, 20),
+        end: createDate(9, 23)
+      },
+      {
+        id: 'november-kayak',
+        title: text.calendar.events.novemberKayak.title,
+        shortLabel: text.calendar.events.novemberKayak.shortLabel,
+        description: text.calendar.events.novemberKayak.description,
+        type: 'kayak',
+        start: createDate(10, 1),
+        end: createDate(10, 3)
+      },
+      {
+        id: 'november-climb',
+        title: text.calendar.events.novemberClimb.title,
+        shortLabel: text.calendar.events.novemberClimb.shortLabel,
+        description: text.calendar.events.novemberClimb.description,
+        type: 'climb',
+        start: createDate(10, 10),
+        end: createDate(10, 13)
+      }
+    ];
+  }, [text.calendar.events]);
   const statusMessage = statusKey ? text.status[statusKey] : '';
   const selectedActivity = useMemo(() => {
     if (selectedActivityId === null) {
@@ -374,6 +414,12 @@ function App() {
         </div>
       </header>
       <main className="max-w-5xl mx-auto px-4 py-10 space-y-12">
+        <ActivityCalendar
+          months={calendarMonths}
+          events={seasonalEvents}
+          locale={locale}
+          text={text.calendar}
+        />
         <section className="grid gap-6 md:grid-cols-2">
           {heroActivities.map(activity => (
             <article key={activity.id} className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">

--- a/frontend/src/components/ActivityCalendar.js
+++ b/frontend/src/components/ActivityCalendar.js
@@ -1,0 +1,221 @@
+import { useMemo } from 'react';
+
+const EVENT_TYPE_STYLES = {
+  climb: {
+    cell: 'border-emerald-200 bg-emerald-50',
+    label: 'text-emerald-700',
+    dot: 'bg-emerald-500'
+  },
+  kayak: {
+    cell: 'border-sky-200 bg-sky-50',
+    label: 'text-sky-700',
+    dot: 'bg-sky-500'
+  }
+};
+
+const createUtcDate = (year, month, day) => new Date(Date.UTC(year, month, day));
+
+const formatKey = date => date.toISOString().split('T')[0];
+
+const addDays = (date, amount) => {
+  const copy = new Date(date.getTime());
+  copy.setUTCDate(copy.getUTCDate() + amount);
+  return copy;
+};
+
+const formatGoogleDate = date => {
+  const iso = date.toISOString().replace(/[-:]/g, '');
+  return iso.split('.')[0] + 'Z';
+};
+
+const formatGoogleAllDay = date => date.toISOString().split('T')[0].replace(/-/g, '');
+
+const ActivityCalendar = ({ months, events, locale, text }) => {
+  const weekdayNames = useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, { weekday: 'short' });
+    return Array.from({ length: 7 }, (_, index) =>
+      formatter
+        .format(createUtcDate(2023, 0, index + 1))
+        .replace('.', '')
+    );
+  }, [locale]);
+
+  const monthMatrices = useMemo(() => {
+    return months.map(monthInfo => {
+      const firstDay = createUtcDate(monthInfo.year, monthInfo.month, 1);
+      const daysInMonth = createUtcDate(monthInfo.year, monthInfo.month + 1, 0).getUTCDate();
+      const leadingEmptyDays = firstDay.getUTCDay();
+      const cells = [];
+
+      for (let i = 0; i < leadingEmptyDays; i += 1) {
+        cells.push(null);
+      }
+
+      for (let day = 1; day <= daysInMonth; day += 1) {
+        cells.push(createUtcDate(monthInfo.year, monthInfo.month, day));
+      }
+
+      while (cells.length % 7 !== 0) {
+        cells.push(null);
+      }
+
+      const weeks = [];
+      for (let i = 0; i < cells.length; i += 7) {
+        weeks.push(cells.slice(i, i + 7));
+      }
+      return { ...monthInfo, weeks };
+    });
+  }, [months]);
+
+  const enrichedEvents = useMemo(() => {
+    return events.map(event => ({
+      ...event,
+      style: EVENT_TYPE_STYLES[event.type] || EVENT_TYPE_STYLES.climb
+    }));
+  }, [events]);
+
+  const eventLookup = useMemo(() => {
+    const map = new Map();
+    enrichedEvents.forEach(event => {
+      let current = new Date(event.start.getTime());
+      while (current <= event.end) {
+        const key = formatKey(current);
+        const existing = map.get(key) || [];
+        existing.push(event);
+        map.set(key, existing);
+        current = addDays(current, 1);
+      }
+    });
+    return map;
+  }, [enrichedEvents]);
+
+  const formatRange = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        month: 'long',
+        day: 'numeric'
+      }),
+    [locale]
+  );
+
+  const googleDateFormatter = useMemo(() => {
+    const hasTime = enrichedEvents.some(event => event.start.getUTCHours() !== 0 || event.end.getUTCHours() !== 0);
+    if (hasTime) {
+      return {
+        toRange: (start, end) => `${formatGoogleDate(start)}/${formatGoogleDate(end)}`
+      };
+    }
+    return {
+      toRange: (start, end) => `${formatGoogleAllDay(start)}/${formatGoogleAllDay(end)}`
+    };
+  }, [enrichedEvents]);
+
+  return (
+    <section className="rounded-3xl bg-white p-6 shadow-lg ring-1 ring-slate-100">
+      <div className="space-y-3">
+        <div className="flex flex-col gap-2 md:flex-row md:items-end md:justify-between">
+          <div>
+            <h2 className="text-2xl font-semibold text-slate-900">{text.heading}</h2>
+            <p className="text-sm text-slate-600">{text.description}</p>
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs">
+            <span className="font-semibold uppercase tracking-wide text-slate-500">{text.legendTitle}</span>
+            {Object.entries(text.legend).map(([type, label]) => {
+              const style = EVENT_TYPE_STYLES[type] || EVENT_TYPE_STYLES.climb;
+              return (
+                <span
+                  key={type}
+                  className="inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1"
+                >
+                  <span className={`h-2 w-2 rounded-full ${style.dot}`} />
+                  <span className="text-slate-600">{label}</span>
+                </span>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-2">
+        {monthMatrices.map(month => (
+          <div key={`${month.year}-${month.month}`} className="rounded-2xl border border-slate-200 p-4">
+            <h3 className="text-lg font-semibold text-slate-800">{month.label}</h3>
+            <div className="mt-4 grid grid-cols-7 text-center text-[11px] uppercase tracking-wide text-slate-500">
+              {weekdayNames.map(name => (
+                <span key={name}>{name}</span>
+              ))}
+            </div>
+            <div className="mt-1 grid grid-cols-7 text-sm">
+              {month.weeks.flat().map((date, index) => {
+                if (!date) {
+                  return <div key={`empty-${index}`} className="min-h-[72px] border border-slate-200 bg-slate-50" />;
+                }
+                const dayEvents = eventLookup.get(formatKey(date)) || [];
+                const classes = [
+                  'min-h-[72px] border border-slate-200 p-2 text-left transition-colors duration-200'
+                ];
+                if (dayEvents.length > 0) {
+                  classes.push(dayEvents[0].style.cell);
+                }
+                return (
+                  <div key={formatKey(date)} className={classes.join(' ')}>
+                    <div className="flex items-start justify-between text-xs font-semibold text-slate-700">
+                      <span>{date.getUTCDate()}</span>
+                      {dayEvents.length > 0 && (
+                        <span className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${dayEvents[0].style.label}`}>
+                          {text.legend[dayEvents[0].type]}
+                        </span>
+                      )}
+                    </div>
+                    {dayEvents.map(event => (
+                      <p key={event.id} className={`mt-1 text-[11px] font-medium ${event.style.label}`}>
+                        {event.shortLabel || event.title}
+                      </p>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 space-y-4">
+        {enrichedEvents.map(event => {
+          const exclusiveEnd = addDays(event.end, 1);
+          const googleUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+            event.title
+          )}&dates=${googleDateFormatter.toRange(event.start, exclusiveEnd)}&details=${encodeURIComponent(
+            `${event.description}\n${text.location}`
+          )}&location=${encodeURIComponent(text.location)}&sf=true&output=xml`;
+
+          const rangeLabel = `${formatRange.format(event.start)} – ${formatRange.format(event.end)}`;
+
+          return (
+            <div
+              key={event.id}
+              className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="space-y-1">
+                <h4 className="text-base font-semibold text-slate-900">{event.title}</h4>
+                <p className="text-sm text-slate-600">{event.description}</p>
+                <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{rangeLabel}</p>
+              </div>
+              <a
+                href={googleUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-slate-800"
+              >
+                <span className="text-lg">＋</span>
+                {text.addToGoogle}
+              </a>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default ActivityCalendar;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -24,6 +24,38 @@ export const translations = {
         'Spots, payments, and deliverables secured by the Edge City contract.'
       ]
     },
+    calendar: {
+      heading: 'October & November expedition calendar',
+      description: 'Preview the exact days blocked for climbing and kayak sessions during the residency.',
+      legendTitle: 'Activities',
+      legend: {
+        climb: 'Climbing',
+        kayak: 'Kayak'
+      },
+      months: {
+        october: 'October 2024',
+        november: 'November 2024'
+      },
+      location: 'Lago Lolog · Patagonia, Argentina',
+      addToGoogle: 'Add to Google Calendar',
+      events: {
+        octoberClimb: {
+          title: 'Rock climbing immersion',
+          shortLabel: 'Climb',
+          description: 'Guided multi-pitch progression on the granite walls from October 20 to 23.'
+        },
+        novemberKayak: {
+          title: 'Kayak crossings on Lolog Lake',
+          shortLabel: 'Kayak',
+          description: 'Sunrise and sunset paddles across the lake from November 1 to 3.'
+        },
+        novemberClimb: {
+          title: 'Granite summit climbing block',
+          shortLabel: 'Climb',
+          description: 'Advanced crack and slab clinics from November 10 to 13.'
+        }
+      }
+    },
     contract: {
       heading: 'Edge City x Patagonia smart contract',
       paragraph1:
@@ -107,6 +139,38 @@ export const translations = {
         'Cocina de territorio y rituales artísticos con Iván Moritz Karl.',
         'Cupos, pagos y entregables asegurados en el contrato Edge City.'
       ]
+    },
+    calendar: {
+      heading: 'Calendario de expediciones octubre y noviembre',
+      description: 'Visualizá los días exactos reservados para las sesiones de escalada y kayak durante la residencia.',
+      legendTitle: 'Actividades',
+      legend: {
+        climb: 'Escalada',
+        kayak: 'Kayak'
+      },
+      months: {
+        october: 'Octubre 2024',
+        november: 'Noviembre 2024'
+      },
+      location: 'Lago Lolog · Patagonia, Argentina',
+      addToGoogle: 'Agregar a Google Calendar',
+      events: {
+        octoberClimb: {
+          title: 'Inmersión de escalada en roca',
+          shortLabel: 'Escalada',
+          description: 'Progresión guiada en rutas de granito del 20 al 23 de octubre.'
+        },
+        novemberKayak: {
+          title: 'Travesías en kayak por el lago Lolog',
+          shortLabel: 'Kayak',
+          description: 'Remadas al amanecer y atardecer del 1 al 3 de noviembre.'
+        },
+        novemberClimb: {
+          title: 'Bloque de cumbres en granito',
+          shortLabel: 'Escalada',
+          description: 'Clínicas avanzadas de fisura y placa del 10 al 13 de noviembre.'
+        }
+      }
     },
     contract: {
       heading: 'Contrato Edge City x Patagonia',


### PR DESCRIPTION
## Summary
- add an ActivityCalendar component to render October and November schedules with Tailwind styling
- populate localized calendar copy and hardcoded expedition events in both English and Spanish
- surface the calendar on the landing page with Google Calendar export links for each activity block

## Testing
- npm --prefix frontend test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68d42c90101c83338f6832c99e3a3003