### PR TITLE
Move calendar section below activities

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -414,12 +414,6 @@ function App() {
         </div>
       </header>
       <main className="max-w-5xl mx-auto px-4 py-10 space-y-12">
-        <ActivityCalendar
-          months={calendarMonths}
-          events={seasonalEvents}
-          locale={locale}
-          text={text.calendar}
-        />
         <section className="grid gap-6 md:grid-cols-2">
           {heroActivities.map(activity => (
             <article key={activity.id} className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">
@@ -638,6 +632,13 @@ function App() {
             </div>
           )}
         </section>
+
+        <ActivityCalendar
+          months={calendarMonths}
+          events={seasonalEvents}
+          locale={locale}
+          text={text.calendar}
+        />
 
         {isAdmin && (
           <section className="rounded bg-white p-6 shadow space-y-4">


### PR DESCRIPTION
## Summary
- relocate the activity calendar component so it renders after the activity listings on the main page

## Testing
- npm run lint *(fails: Missing script "lint" in frontend/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68d4466da6388333b1ca9d17cae4f9f0