### PR TITLE
Add gallery support for residency experiences

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import { ethers } from 'ethers';
 import ActivityRegistry from './ActivityRegistry.json';
 import Navbar from './components/Navbar';
 import ActivityCalendar from './components/ActivityCalendar';
+import ActivityCard from './components/ActivityCard';
 import { translations, residencyActivities as residencyCatalog, localeMap } from './translations';
 
 const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
@@ -46,7 +47,7 @@ function App() {
     () =>
       residencyCatalog.map(activity => {
         const localized = activity.translations[language] || activity.translations.en;
-        return { ...localized, id: activity.id, image: activity.image };
+        return { ...localized, id: activity.id, images: activity.images || [] };
       }),
     [language]
   );
@@ -439,29 +440,7 @@ function App() {
       <main className="max-w-5xl mx-auto px-4 py-10 space-y-12">
         <section className="grid gap-6 md:grid-cols-2">
           {heroActivities.map(activity => (
-            <article key={activity.id} className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">
-              <div className="relative h-56 overflow-hidden">
-                <img
-                  src={activity.image}
-                  alt={activity.title}
-                  className="h-full w-full object-cover transition-transform duration-700 hover:scale-105"
-                  loading="lazy"
-                />
-              </div>
-              <div className="space-y-3 px-6 py-6">
-                <h3 className="text-xl font-semibold text-slate-900">{activity.title}</h3>
-                <p className="text-sm text-slate-600">{activity.summary}</p>
-                <ul className="space-y-2 text-sm text-slate-700">
-                  {activity.highlights.map(highlight => (
-                    <li key={highlight} className="flex items-start gap-2">
-                      <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
-                      {highlight}
-                    </li>
-                  ))}
-                </ul>
-                <p className="text-xs uppercase tracking-wide text-slate-500">{activity.guide}</p>
-              </div>
-            </article>
+            <ActivityCard key={activity.id} activity={activity} />
           ))}
         </section>
 

--- a/frontend/src/components/ActivityCard.js
+++ b/frontend/src/components/ActivityCard.js
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+
+function ActivityCard({ activity }) {
+  const { title, summary, highlights = [], guide, images = [] } = activity;
+  const safeImages = useMemo(() => (images.length > 0 ? images : ['']), [images]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const showNavigation = safeImages.length > 1;
+  const currentImage = safeImages[currentIndex] || '';
+
+  const goToIndex = index => {
+    setCurrentIndex((index + safeImages.length) % safeImages.length);
+  };
+
+  const goNext = () => {
+    goToIndex(currentIndex + 1);
+  };
+
+  const goPrev = () => {
+    goToIndex(currentIndex - 1);
+  };
+
+  return (
+    <article className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">
+      <div className="relative h-56 overflow-hidden">
+        {currentImage && (
+          <img
+            src={currentImage}
+            alt={title}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        )}
+        {showNavigation && (
+          <>
+            <button
+              type="button"
+              onClick={goPrev}
+              className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition hover:bg-black/70"
+              aria-label="Previous image"
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              onClick={goNext}
+              className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-black/50 p-2 text-white transition hover:bg-black/70"
+              aria-label="Next image"
+            >
+              ›
+            </button>
+            <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 gap-2">
+              {safeImages.map((_, index) => (
+                <button
+                  key={index}
+                  type="button"
+                  onClick={() => goToIndex(index)}
+                  className={`h-2 w-2 rounded-full transition ${
+                    index === currentIndex ? 'bg-white' : 'bg-white/40'
+                  }`}
+                  aria-label={`Show image ${index + 1}`}
+                />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+      <div className="space-y-3 px-6 py-6">
+        <h3 className="text-xl font-semibold text-slate-900">{title}</h3>
+        <p className="text-sm text-slate-600">{summary}</p>
+        <ul className="space-y-2 text-sm text-slate-700">
+          {highlights.map(highlight => (
+            <li key={highlight} className="flex items-start gap-2">
+              <span className="mt-1 h-2 w-2 flex-shrink-0 rounded-full bg-blue-500" />
+              {highlight}
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs uppercase tracking-wide text-slate-500">{guide}</p>
+      </div>
+    </article>
+  );
+}
+
+export default ActivityCard;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -521,7 +521,10 @@ export const localeMap = {
 export const residencyActivities = [
   {
     id: 'patagonian-asado',
-    image: 'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
+    images: [
+      'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
+      'https://ipfs.io/ipfs/bafybeifqkwx3c6rr7d22sdnmss5j6atmkvsis5ivh42gdwfcy3znssaw5m'
+    ],
     translations: {
       en: {
         title: 'Intimate Patagonian asado on the lakeshore',
@@ -593,7 +596,7 @@ export const residencyActivities = [
   },
   {
     id: 'mountain-expedition',
-    image: 'https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru',
+    images: ['https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru'],
     translations: {
       en: {
         title: 'Mountain expedition to the heart of the Andes',
@@ -665,7 +668,7 @@ export const residencyActivities = [
   },
   {
     id: 'lake-kayak',
-    image: 'https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q',
+    images: ['https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q'],
     translations: {
       en: {
         title: 'Kayak journey across Lake Lolog',
@@ -737,7 +740,7 @@ export const residencyActivities = [
   },
   {
     id: 'rock-climbing',
-    image: 'https://ipfs.io/ipfs/bafkreiazmgq5d4xq72ggid33nkh4fozsn6ek6feaf3oqes3mczybyjyqca',
+    images: ['https://ipfs.io/ipfs/bafkreiazmgq5d4xq72ggid33nkh4fozsn6ek6feaf3oqes3mczybyjyqca'],
     translations: {
       en: {
         title: 'Rock-climbing clinic and mindful movement',


### PR DESCRIPTION
## Summary
- replace residency activity images with galleries and add a second photo to the Patagonian asado experience
- introduce a reusable ActivityCard component with carousel controls for browsing images
- wire the hero section to use the new gallery data when rendering featured experiences

## Testing
- `cd frontend && npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68d74ec93a1883339def52f948ddcd3d