### PR TITLE
Add image galleries to residency experiences

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import { ethers } from 'ethers';
 import ActivityRegistry from './ActivityRegistry.json';
 import Navbar from './components/Navbar';
 import ActivityCalendar from './components/ActivityCalendar';
+import ActivityGallery from './components/ActivityGallery';
 import { translations, residencyActivities as residencyCatalog, localeMap } from './translations';
 
 const contractAddress = process.env.REACT_APP_CONTRACT_ADDRESS || '';
@@ -46,7 +47,11 @@ function App() {
     () =>
       residencyCatalog.map(activity => {
         const localized = activity.translations[language] || activity.translations.en;
-        return { ...localized, id: activity.id, image: activity.image };
+        return {
+          ...localized,
+          id: activity.id,
+          images: activity.images && activity.images.length > 0 ? activity.images : [activity.image].filter(Boolean)
+        };
       }),
     [language]
   );
@@ -443,14 +448,7 @@ function App() {
 
             return (
               <article key={activity.id} className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">
-                <div className="relative h-56 overflow-hidden">
-                  <img
-                    src={activity.image}
-                    alt={activity.title}
-                    className="h-full w-full object-cover transition-transform duration-700 hover:scale-105"
-                    loading="lazy"
-                  />
-                </div>
+                <ActivityGallery images={activity.images} alt={activity.title} />
                 <div className="relative overflow-hidden px-6 py-6">
                   {isPatagonianAsado && (
                     <>

--- a/frontend/src/components/ActivityGallery.js
+++ b/frontend/src/components/ActivityGallery.js
@@ -1,0 +1,91 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function ActivityGallery({ images = [], alt }) {
+  const gallery = useMemo(() => images.filter(Boolean), [images]);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  useEffect(() => {
+    if (gallery.length === 0) {
+      setActiveIndex(0);
+      return;
+    }
+    if (activeIndex >= gallery.length) {
+      setActiveIndex(0);
+    }
+  }, [gallery, activeIndex]);
+
+  if (gallery.length === 0) {
+    return null;
+  }
+
+  const showControls = gallery.length > 1;
+
+  const goToIndex = index => {
+    setActiveIndex((index + gallery.length) % gallery.length);
+  };
+
+  const goToPrev = () => {
+    goToIndex(activeIndex - 1);
+  };
+
+  const goToNext = () => {
+    goToIndex(activeIndex + 1);
+  };
+
+  return (
+    <div className="relative h-56 overflow-hidden">
+      {gallery.map((src, index) => (
+        <img
+          key={src}
+          src={src}
+          alt={index === activeIndex ? alt : ''}
+          className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-500 ${
+            index === activeIndex ? 'opacity-100' : 'opacity-0'
+          }`}
+          loading="lazy"
+          aria-hidden={index !== activeIndex}
+        />
+      ))}
+
+      {showControls && (
+        <>
+          <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-black/20 via-transparent to-black/20" aria-hidden="true" />
+          <div className="absolute inset-x-0 top-1/2 flex -translate-y-1/2 justify-between px-3">
+            <button
+              type="button"
+              onClick={goToPrev}
+              className="pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-slate-800 shadow hover:bg-white"
+              aria-label="Previous image"
+            >
+              ‹
+            </button>
+            <button
+              type="button"
+              onClick={goToNext}
+              className="pointer-events-auto inline-flex h-9 w-9 items-center justify-center rounded-full bg-white/80 text-slate-800 shadow hover:bg-white"
+              aria-label="Next image"
+            >
+              ›
+            </button>
+          </div>
+          <div className="absolute bottom-3 left-1/2 flex -translate-x-1/2 gap-2">
+            {gallery.map((src, index) => (
+              <button
+                key={`${src}-${index}`}
+                type="button"
+                onClick={() => goToIndex(index)}
+                className={`pointer-events-auto h-2.5 w-2.5 rounded-full transition ${
+                  index === activeIndex ? 'bg-white' : 'bg-white/50'
+                }`}
+                aria-label={`Show image ${index + 1}`}
+                aria-current={index === activeIndex ? 'true' : undefined}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ActivityGallery;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -521,6 +521,10 @@ export const localeMap = {
 export const residencyActivities = [
   {
     id: 'patagonian-asado',
+    images: [
+      'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
+      'https://ipfs.io/ipfs/bafybeifqkwx3c6rr7d22sdnmss5j6atmkvsis5ivh42gdwfcy3znssaw5m'
+    ],
     image: 'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
     translations: {
       en: {
@@ -593,6 +597,7 @@ export const residencyActivities = [
   },
   {
     id: 'mountain-expedition',
+    images: ['https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru'],
     image: 'https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru',
     translations: {
       en: {
@@ -665,6 +670,7 @@ export const residencyActivities = [
   },
   {
     id: 'lake-kayak',
+    images: ['https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q'],
     image: 'https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q',
     translations: {
       en: {


### PR DESCRIPTION
## Summary
- add a reusable ActivityGallery carousel component for residency experience cards
- surface all localized experience images through the gallery and enrich the Patagonian asado with a second photo
- integrate the gallery into the hero experiences grid so users can browse multiple visuals per activity

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7625d727c8333a1920c20c3d84080