### PR TITLE
Add gallery support for residency experiences

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -50,7 +50,7 @@ function App() {
         return {
           ...localized,
           id: activity.id,
-          images: activity.images && activity.images.length > 0 ? activity.images : [activity.image].filter(Boolean)
+          images: activity.images ? activity.images.filter(Boolean) : []
         };
       }),
     [language]

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -653,7 +653,6 @@ export const residencyActivities = [
       'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
       'https://ipfs.io/ipfs/bafybeifqkwx3c6rr7d22sdnmss5j6atmkvsis5ivh42gdwfcy3znssaw5m'
     ],
-    image: 'https://ipfs.io/ipfs/bafybeic23gavkexic2nmmccmknbff4ngwhzhzqxcic7qdzbysc7rzeyzo4',
     translations: {
       en: {
         title: 'Intimate Patagonian asado on the lakeshore',
@@ -726,7 +725,6 @@ export const residencyActivities = [
   {
     id: 'mountain-expedition',
     images: ['https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru'],
-    image: 'https://ipfs.io/ipfs/bafybeienxvgvzj4a4qhozas5cd5hgnkk2dkkylnv4q6tiypqz6qqxswwru',
     translations: {
       en: {
         title: 'Mountain expedition to the heart of the Andes',
@@ -799,7 +797,6 @@ export const residencyActivities = [
   {
     id: 'lake-kayak',
     images: ['https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q'],
-    image: 'https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q',
     translations: {
       en: {
         title: 'Kayak journey across Lake Lolog',
@@ -871,7 +868,7 @@ export const residencyActivities = [
   },
   {
     id: 'rock-climbing',
-    image: 'https://ipfs.io/ipfs/bafkreiazmgq5d4xq72ggid33nkh4fozsn6ek6feaf3oqes3mczybyjyqca',
+    images: ['https://ipfs.io/ipfs/bafkreiazmgq5d4xq72ggid33nkh4fozsn6ek6feaf3oqes3mczybyjyqca'],
     translations: {
       en: {
         title: 'Rock-climbing clinic and mindful movement',


### PR DESCRIPTION
## Summary
- rely on activity image galleries when building the residency cards
- clean up residency activity seeds to store images as explicit arrays and add the Patagonian asado gallery asset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d767e1348c8333b93951e349bbd24c