### PR TITLE
Add example environment configuration for frontend

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,8 @@
+# Environment configuration for the Edge City residency dashboard
+# Copy this file to `.env` and fill in the addresses for your deployment.
+
+# Address of the deployed ActivityRegistry contract
+REACT_APP_CONTRACT_ADDRESS=0x0000000000000000000000000000000000000000
+
+# Address of the ERC20 token (e.g., USDT) used for activity payments
+REACT_APP_USDT_ADDRESS=0x0000000000000000000000000000000000000000


### PR DESCRIPTION
## Summary
- add a `.env.example` file for the frontend dashboard
- document the required contract and token address variables with placeholder values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4b89e8248333a768c50b4fdd2284