### PR TITLE
Clarify payment configuration guidance

### DIFF
--- a/frontend/src/components/ActivityRegistration.js
+++ b/frontend/src/components/ActivityRegistration.js
@@ -16,11 +16,34 @@ function ActivityRegistration({ activity, account, getProvider, text }) {
   const usdtAddress = process.env.REACT_APP_USDT_ADDRESS;
   const destinationWallet = process.env.REACT_APP_DESTINATION_WALLET;
 
-  const hasPaymentConfig = Boolean(usdtAddress && destinationWallet);
-
   const agendaText = text?.agenda || {};
   const statusText = text?.status || {};
   const warningsText = text?.warnings || {};
+
+  const hasPaymentConfig = Boolean(usdtAddress && destinationWallet);
+
+  const destinationWarning = warningsText.destination;
+  const usdtWarning = warningsText.usdt;
+
+  const missingPaymentConfigMessage = useMemo(() => {
+    if (!usdtAddress && usdtWarning) {
+      return usdtWarning;
+    }
+
+    if (!destinationWallet && destinationWarning) {
+      return destinationWarning;
+    }
+
+    if (!destinationWallet) {
+      return 'Set the destination wallet environment variable to enable registrations.';
+    }
+
+    if (!usdtAddress) {
+      return 'Set the USDT token address environment variable to enable registrations.';
+    }
+
+    return destinationWarning || usdtWarning || 'Payment configuration is missing.';
+  }, [destinationWallet, destinationWarning, usdtAddress, usdtWarning]);
 
   useEffect(() => {
     let cancelled = false;
@@ -95,9 +118,7 @@ function ActivityRegistration({ activity, account, getProvider, text }) {
     }
 
     if (!hasPaymentConfig) {
-      setStatusMessage(
-        warningsText.destination || warningsText.usdt || 'Payment configuration is missing.'
-      );
+      setStatusMessage(missingPaymentConfigMessage);
       return;
     }
 

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -57,7 +57,8 @@ export const translations = {
       }
     },
     warnings: {
-      destination: 'Set <code>REACT_APP_DESTINATION_WALLET</code> to receive the registration transactions.'
+      destination: 'Set <code>REACT_APP_DESTINATION_WALLET</code> to receive the registration transactions.',
+      usdt: 'Set <code>REACT_APP_USDT_ADDRESS</code> to target the USDT token used for registrations.'
     },
     status: {
       connectWalletToRegister: 'Connect your wallet to send the registration.',
@@ -152,7 +153,8 @@ export const translations = {
       }
     },
     warnings: {
-      destination: 'Configurá <code>REACT_APP_DESTINATION_WALLET</code> para recibir las transacciones de registro.'
+      destination: 'Configurá <code>REACT_APP_DESTINATION_WALLET</code> para recibir las transacciones de registro.',
+      usdt: 'Configurá <code>REACT_APP_USDT_ADDRESS</code> para apuntar al token USDT usado en los registros.'
     },
     status: {
       connectWalletToRegister: 'Conectá tu wallet para enviar el registro.',


### PR DESCRIPTION
## Summary
- clarify payment configuration handling so missing environment variables surface more accurate guidance
- add explicit USDT address warning copy for English and Spanish translations
- fix warnings lookup order to avoid runtime ReferenceError when payment configuration is missing

## Testing
- npm --prefix frontend test -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68dc497393fc833385be3f215cdfea4c