### PR TITLE
Ensure wallet connections switch to Ethereum mainnet

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,8 @@ import ActivityGallery from './components/ActivityGallery';
 import ActivityRegistration from './components/ActivityRegistration';
 import { translations, residencyActivities as residencyCatalog, localeMap } from './translations';
 
+const ETHEREUM_MAINNET_CHAIN_ID = '0x1';
+
 function App() {
   const [account, setAccount] = useState(null);
   const [language, setLanguage] = useState('en');
@@ -96,6 +98,28 @@ function App() {
       window.ethereum.removeListener('accountsChanged', handleAccountsChanged);
     };
   }, [hasProvider]);
+
+  const ensureEthereumNetwork = useCallback(
+    async provider => {
+      try {
+        const chainId = await provider.send('eth_chainId', []);
+        if (chainId === ETHEREUM_MAINNET_CHAIN_ID) {
+          return true;
+        }
+
+        await provider.send('wallet_switchEthereumChain', [
+          { chainId: ETHEREUM_MAINNET_CHAIN_ID }
+        ]);
+        return true;
+      } catch (error) {
+        console.error('Failed to ensure Ethereum network', error);
+        alert(text.alerts.wrongNetwork || 'Switch to the Ethereum network in your wallet to continue.');
+        return false;
+      }
+    },
+    [text.alerts]
+  );
+
   const connect = async () => {
     if (!hasProvider) {
       alert(text.alerts.metaMask);
@@ -103,6 +127,15 @@ function App() {
     }
     try {
       const provider = getProvider();
+      if (!provider) {
+        return;
+      }
+
+      const networkReady = await ensureEthereumNetwork(provider);
+      if (!networkReady) {
+        return;
+      }
+
       const accounts = await provider.send('eth_requestAccounts', []);
       if (accounts.length) {
         const normalized = ethers.utils.getAddress(accounts[0]);

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -74,7 +74,8 @@ export const translations = {
       processingRegistration: 'We are processing your registration.'
     },
     alerts: {
-      metaMask: 'Install MetaMask to continue.'
+      metaMask: 'Install MetaMask to continue.',
+      wrongNetwork: 'Switch to the Ethereum network in your wallet to continue.'
     },
     agenda: {
       detailsButton: 'View details',
@@ -170,7 +171,8 @@ export const translations = {
       processingRegistration: 'Estamos procesando tu registro.'
     },
     alerts: {
-      metaMask: 'Instalá MetaMask para continuar.'
+      metaMask: 'Instalá MetaMask para continuar.',
+      wrongNetwork: 'Cambiá tu wallet a la red de Ethereum para continuar.'
     },
     agenda: {
       detailsButton: 'Ver detalles',
@@ -266,7 +268,8 @@ export const translations = {
       processingRegistration: 'Nous traitons votre inscription.'
     },
     alerts: {
-      metaMask: 'Installez MetaMask pour continuer.'
+      metaMask: 'Installez MetaMask pour continuer.',
+      wrongNetwork: 'Basculez votre wallet sur le réseau Ethereum pour continuer.'
     },
     agenda: {
       loading: 'Chargement des activités…',
@@ -373,7 +376,8 @@ export const translations = {
       processingRegistration: 'Wir verarbeiten deine Anmeldung.'
     },
     alerts: {
-      metaMask: 'Installiere MetaMask, um fortzufahren.'
+      metaMask: 'Installiere MetaMask, um fortzufahren.',
+      wrongNetwork: 'Wechsle in deiner Wallet zum Ethereum-Netzwerk, um fortzufahren.'
     },
     agenda: {
       loading: 'Aktivitäten werden geladen...',
@@ -480,7 +484,8 @@ export const translations = {
       processingRegistration: '我们正在处理您的报名。'
     },
     alerts: {
-      metaMask: '请安装 MetaMask 以继续。'
+      metaMask: '请安装 MetaMask 以继续。',
+      wrongNetwork: '请在钱包中切换到以太坊网络后再继续。'
     },
     agenda: {
       loading: '正在加载活动…',
@@ -587,7 +592,8 @@ export const translations = {
       processingRegistration: 'Мы обрабатываем вашу регистрацию.'
     },
     alerts: {
-      metaMask: 'Установите MetaMask, чтобы продолжить.'
+      metaMask: 'Установите MetaMask, чтобы продолжить.',
+      wrongNetwork: 'Переключите кошелёк на сеть Ethereum, чтобы продолжить.'
     },
     agenda: {
       loading: 'Загрузка активностей…',


### PR DESCRIPTION
## Summary
- ensure wallet connections request the Ethereum mainnet and attempt to switch automatically when connecting
- extend localized alert messages with copy for wrong network notifications

## Testing
- npm --prefix frontend run build

------
https://chatgpt.com/codex/tasks/task_e_68dc4eb7d7cc8333b18bce89dcde305e