### PR TITLE
Add network selector with hardcoded USDT contract addresses

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,9 +7,44 @@ import ActivityGallery from './components/ActivityGallery';
 import ActivityRegistration from './components/ActivityRegistration';
 import { translations, residencyActivities as residencyCatalog, localeMap } from './translations';
 
+const NETWORKS = [
+  {
+    id: 'ethereum',
+    label: 'Ethereum',
+    chainId: 1,
+    usdtAddress: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+    explorerUrl: 'https://etherscan.io/token/0xdac17f958d2ee523a2206206994597c13d831ec7',
+    type: 'evm'
+  },
+  {
+    id: 'avalanche',
+    label: 'Avalanche C-Chain',
+    chainId: 43114,
+    usdtAddress: '0x9702230A8Ea53601f5CD2dc00fDBc13d4Df4A8C7',
+    explorerUrl: 'https://snowtrace.io/token/0x9702230a8ea53601f5cd2dc00fdbc13d4df4a8c7',
+    type: 'evm'
+  },
+  {
+    id: 'kava',
+    label: 'Kava EVM (Cosmos)',
+    chainId: 2222,
+    usdtAddress: '0x919C1c267BC06a7039E03Fcc2eF738525769109c',
+    explorerUrl: 'https://kavascan.com/address/0x919C1c267BC06a7039e03fcc2eF738525769109c',
+    type: 'evm'
+  },
+  {
+    id: 'tron',
+    label: 'Tron (TRC20)',
+    usdtAddress: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    explorerUrl: 'https://tronscan.org/#/token20/TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+    type: 'tron'
+  }
+];
+
 function App() {
   const [account, setAccount] = useState(null);
   const [language, setLanguage] = useState('en');
+  const [selectedNetworkId, setSelectedNetworkId] = useState(NETWORKS[0].id);
 
   const text = useMemo(() => translations[language] || translations.en, [language]);
   const languageOptions = useMemo(
@@ -18,6 +53,10 @@ function App() {
         .filter(code => translations[code])
         .map(code => ({ code, label: translations[code].languageName })),
     []
+  );
+  const selectedNetwork = useMemo(
+    () => NETWORKS.find(network => network.id === selectedNetworkId) || NETWORKS[0],
+    [selectedNetworkId]
   );
   const heroActivities = useMemo(
     () =>
@@ -128,6 +167,10 @@ function App() {
         text={text.navbar}
         languageLabel={text.languageSelectorLabel}
         languageOptions={languageOptions}
+        networkLabel={text.networkSelectorLabel || 'Network'}
+        networkOptions={NETWORKS}
+        selectedNetworkId={selectedNetwork.id}
+        onSelectNetwork={setSelectedNetworkId}
       />
       <header className="bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
         <div className="max-w-5xl mx-auto px-4 py-16 grid gap-8 lg:grid-cols-[1.2fr,0.8fr] items-center">
@@ -221,6 +264,7 @@ function App() {
                       account={account}
                       getProvider={getProvider}
                       text={text}
+                      selectedNetwork={selectedNetwork}
                     />
                   </div>
                 </div>

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,6 +1,19 @@
 import React from 'react';
 
-function Navbar({ account, connect, disconnect, language, setLanguage, text, languageLabel, languageOptions }) {
+function Navbar({
+  account,
+  connect,
+  disconnect,
+  language,
+  setLanguage,
+  text,
+  languageLabel,
+  languageOptions,
+  networkLabel,
+  networkOptions,
+  selectedNetworkId,
+  onSelectNetwork
+}) {
   return (
     <nav className="bg-white/90 backdrop-blur shadow">
       <div className="max-w-5xl mx-auto px-4 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -9,6 +22,20 @@ function Navbar({ account, connect, disconnect, language, setLanguage, text, lan
           <p className="text-sm text-gray-600">{text.subtitle}</p>
         </div>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+          <label className="flex items-center gap-2 text-sm text-gray-600">
+            <span>{networkLabel}</span>
+            <select
+              value={selectedNetworkId}
+              onChange={event => onSelectNetwork?.(event.target.value)}
+              className="rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {(networkOptions || []).map(option => (
+                <option key={option.id} value={option.id}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
           <label className="flex items-center gap-2 text-sm text-gray-600">
             <span>{languageLabel}</span>
             <select

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -2,6 +2,7 @@ export const translations = {
   en: {
     languageName: 'English',
     languageSelectorLabel: 'Language',
+    networkSelectorLabel: 'Network',
     navbar: {
       title: 'Edge City · Patagonia Experience',
       subtitle: 'An immersive nature experience with every registration confirmed on-chain through a single wallet message.',
@@ -57,8 +58,7 @@ export const translations = {
       }
     },
     warnings: {
-      destination: 'Set <code>REACT_APP_DESTINATION_WALLET</code> to receive the registration transactions.',
-      usdt: 'Set <code>REACT_APP_USDT_ADDRESS</code> to target the USDT token used for registrations.'
+      destination: 'Set <code>REACT_APP_DESTINATION_WALLET</code> to receive the registration transactions.'
     },
     status: {
       connectWalletToRegister: 'Connect your wallet to send the registration.',
@@ -71,7 +71,8 @@ export const translations = {
       confirmingOnChain: 'Waiting for the transaction to confirm...',
       registrationComplete: 'Registration message sent successfully!',
       registrationFailed: 'Could not send the registration. Check the console for more details.',
-      processingRegistration: 'We are processing your registration.'
+      processingRegistration: 'We are processing your registration.',
+      networkUnsupported: 'The {network} network requires a compatible wallet connection to send USDT.'
     },
     alerts: {
       metaMask: 'Install MetaMask to continue.'
@@ -97,6 +98,7 @@ export const translations = {
   es: {
     languageName: 'Español',
     languageSelectorLabel: 'Idioma',
+    networkSelectorLabel: 'Red',
     navbar: {
       title: 'Edge City · Residencia Patagonia',
       subtitle: 'Una experiencia inmersiva en la naturaleza con confirmaciones on-chain enviadas desde tu wallet.',
@@ -153,8 +155,7 @@ export const translations = {
       }
     },
     warnings: {
-      destination: 'Configurá <code>REACT_APP_DESTINATION_WALLET</code> para recibir las transacciones de registro.',
-      usdt: 'Configurá <code>REACT_APP_USDT_ADDRESS</code> para apuntar al token USDT usado en los registros.'
+      destination: 'Configurá <code>REACT_APP_DESTINATION_WALLET</code> para recibir las transacciones de registro.'
     },
     status: {
       connectWalletToRegister: 'Conectá tu wallet para enviar el registro.',
@@ -167,7 +168,8 @@ export const translations = {
       confirmingOnChain: 'Esperando la confirmación en cadena...',
       registrationComplete: '¡Mensaje de registro enviado con éxito!',
       registrationFailed: 'No pudimos enviar el registro. Revisá la consola para más detalles.',
-      processingRegistration: 'Estamos procesando tu registro.'
+      processingRegistration: 'Estamos procesando tu registro.',
+      networkUnsupported: 'La red {network} requiere una conexión de wallet compatible para enviar USDT.'
     },
     alerts: {
       metaMask: 'Instalá MetaMask para continuar.'


### PR DESCRIPTION
## Summary
- hardcode metadata for the supported USDT networks and surface a selector next to the wallet button
- update the activity registration flow to use the selected network and handle unsupported chains gracefully
- refresh translations to include the network label and messaging for unsupported networks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc5cdf77148333809a3d44655a42c5