### PR TITLE
Update README to describe direct wallet payments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,36 @@
 # Edge City · Residency Activity Registry
 
-Edge City documents its Patagonia residency program on-chain. The project combines a Solidity
-smart contract with a React dashboard so organizers can publish activities, manage spots and
-collect USDT payments directly from participant wallets.
+Edge City documents its Patagonia residency program directly on-chain. The project now relies on a
+React dashboard that coordinates activity publishing, spot management and payments routed straight
+to the organizer's wallet—no smart contracts or escrow layers are involved.
 
 ## Platform overview
 
 - Curate multi-day cultural and nature activities for each residency edition.
-- Accept USDT payments that are validated and escrowed by the smart contract.
+- Collect USDT payments that are sent immediately to the organizer's wallet.
 - Track real-time availability, registrations and participant wallets from the dashboard.
-- Offer a multilingual interface (English, Spanish and French) connected to the blockchain data.
+- Offer a multilingual interface (English, Spanish and French) connected to the residency data.
 
-## Smart contracts
+## Payment flow
 
-### `contracts/ActivityRegistry.sol`
-
-The core contract stores the activity catalog. Administrators can create experiences, toggle their
-status and configure pricing in USDT. Participants call `registerForActivity` to secure their spot
-and transfer the required stablecoin amount to the organizer in a single transaction. Public getters
-expose activity metadata, availability counters, the current admin and the stablecoin address used
-for payments.
-
-### `contracts/mocks/TestToken.sol`
-
-A lightweight ERC20-like token included for local development and testing. It exposes minting and
-standard allowance flows so Hardhat tests can emulate USDT behaviour.
+Participants pay by signing a transaction from their wallet that transfers USDT directly to the
+organizer. The dashboard validates the transaction hash and updates internal records so availability
+and participant rosters stay current.
 
 ## Frontend
 
-The `frontend` folder contains a React application that surfaces contract data and lets admins
+The `frontend` folder contains a React application that surfaces residency data and lets admins
 publish activities once they connect their wallet. Update the following environment variables to
 point at your deployment:
 
-- `REACT_APP_CONTRACT_ADDRESS`: address of the deployed `ActivityRegistry` contract.
+- `REACT_APP_ORGANIZER_WALLET`: wallet address that receives participant payments.
 - `REACT_APP_USDT_ADDRESS`: address of the ERC20 token accepted for payments.
 
 ## Getting started
 
 ```bash
 npm install
-npm run compile
+npm run build
 npm test
 ```
 
@@ -51,5 +42,5 @@ npm install
 npm start
 ```
 
-Deploy the contracts with Hardhat, configure the frontend environment variables, and the dashboard
-will reflect the live on-chain activity data.
+Configure the organizer wallet in your environment variables, launch the dashboard, and you'll see
+live availability updates as participants complete their transfers.


### PR DESCRIPTION
## Summary
- refresh the README to clarify that payments now go straight to the organizer wallet
- document the new organizer wallet environment variable and updated payment flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc61841d2c8333ab9158a4c94788c5