### PR TITLE
Add participant profile modal before wallet connection

### DIFF
--- a/frontend/src/components/ParticipantInfoModal.js
+++ b/frontend/src/components/ParticipantInfoModal.js
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from 'react';
+
+function ParticipantInfoModal({ isOpen, onClose, onSubmit, text = {}, initialValues }) {
+  const [formValues, setFormValues] = useState({
+    firstName: '',
+    lastName: '',
+    idType: 'dni',
+    idNumber: '',
+    accommodation: '',
+    nationality: '',
+    birthDate: ''
+  });
+  const [errors, setErrors] = useState({});
+
+  const idTypeOptions = useMemo(
+    () => [
+      { value: 'dni', label: text.idTypeDni || 'DNI' },
+      { value: 'passport', label: text.idTypePassport || 'Passport' },
+      { value: 'other', label: text.idTypeOther || 'Other' }
+    ],
+    [text.idTypeDni, text.idTypePassport, text.idTypeOther]
+  );
+
+  useEffect(() => {
+    if (!initialValues) {
+      return;
+    }
+    setFormValues(prev => ({
+      ...prev,
+      ...initialValues
+    }));
+  }, [initialValues]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setErrors({});
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleChange = event => {
+    const { name, value } = event.target;
+    setFormValues(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const validate = values => {
+    const newErrors = {};
+    const requiredMessage = text.requiredField || 'This field is required.';
+
+    ['firstName', 'lastName', 'idType', 'idNumber', 'accommodation', 'nationality', 'birthDate'].forEach(field => {
+      if (!values[field]) {
+        newErrors[field] = requiredMessage;
+      }
+    });
+
+    return newErrors;
+  };
+
+  const handleSubmit = event => {
+    event.preventDefault();
+    const validationErrors = validate(formValues);
+    if (Object.keys(validationErrors).length) {
+      setErrors(validationErrors);
+      return;
+    }
+    setErrors({});
+    onSubmit?.(formValues);
+  };
+
+  const title = text.title || 'Participant information';
+  const description =
+    text.description ||
+    'Complete these details so we can share the activity registration with the hosts.';
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 px-4 py-6">
+      <div className="w-full max-w-xl rounded-3xl bg-white p-6 shadow-2xl">
+        <div className="mb-5 space-y-2 text-slate-700">
+          <h2 className="text-xl font-semibold text-slate-900">{title}</h2>
+          <p className="text-sm text-slate-600">{description}</p>
+        </div>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-first-name">
+                {text.firstNameLabel || 'First name'}
+              </label>
+              <input
+                id="participant-first-name"
+                name="firstName"
+                type="text"
+                value={formValues.firstName}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              />
+              {errors.firstName && <p className="mt-1 text-xs text-red-600">{errors.firstName}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-last-name">
+                {text.lastNameLabel || 'Last name'}
+              </label>
+              <input
+                id="participant-last-name"
+                name="lastName"
+                type="text"
+                value={formValues.lastName}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              />
+              {errors.lastName && <p className="mt-1 text-xs text-red-600">{errors.lastName}</p>}
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-id-type">
+                {text.idTypeLabel || 'Identification type'}
+              </label>
+              <select
+                id="participant-id-type"
+                name="idType"
+                value={formValues.idType}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              >
+                {idTypeOptions.map(option => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+              {errors.idType && <p className="mt-1 text-xs text-red-600">{errors.idType}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-id-number">
+                {text.idNumberLabel || 'Identification number'}
+              </label>
+              <input
+                id="participant-id-number"
+                name="idNumber"
+                type="text"
+                value={formValues.idNumber}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              />
+              {errors.idNumber && <p className="mt-1 text-xs text-red-600">{errors.idNumber}</p>}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700" htmlFor="participant-accommodation">
+              {text.accommodationLabel || 'Accommodation'}
+            </label>
+            <input
+              id="participant-accommodation"
+              name="accommodation"
+              type="text"
+              value={formValues.accommodation}
+              onChange={handleChange}
+              className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+              required
+            />
+            {errors.accommodation && <p className="mt-1 text-xs text-red-600">{errors.accommodation}</p>}
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-nationality">
+                {text.nationalityLabel || 'Nationality'}
+              </label>
+              <input
+                id="participant-nationality"
+                name="nationality"
+                type="text"
+                value={formValues.nationality}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              />
+              {errors.nationality && <p className="mt-1 text-xs text-red-600">{errors.nationality}</p>}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700" htmlFor="participant-birth-date">
+                {text.birthDateLabel || 'Birth date'}
+              </label>
+              <input
+                id="participant-birth-date"
+                name="birthDate"
+                type="date"
+                value={formValues.birthDate}
+                onChange={handleChange}
+                className="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-slate-200"
+                required
+              />
+              {errors.birthDate && <p className="mt-1 text-xs text-red-600">{errors.birthDate}</p>}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
+            >
+              {text.cancelButton || 'Cancel'}
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-800"
+            >
+              {text.saveButton || 'Save and continue'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default ParticipantInfoModal;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -79,7 +79,8 @@ export const translations = {
       insufficientBalance: 'Your USDT balance is not sufficient to cover this registration.',
       insufficientBalanceToken: 'Your {token} balance is not sufficient to cover this registration.',
       usdtUnavailable: 'The configured USDT token ({address}) is not deployed on {network}.',
-      tokenUnavailable: 'The configured {token} token ({address}) is not deployed on {network}.'
+      tokenUnavailable: 'The configured {token} token ({address}) is not deployed on {network}.',
+      missingParticipantInfo: 'Complete your participant information before sending a registration.'
 
     },
     alerts: {
@@ -102,6 +103,23 @@ export const translations = {
       participantCountHelper: 'Choose how many seats to reserve.',
       transactionInfo: 'MetaMask will deliver your message on-chain to {wallet}.',
       paymentTokenLabel: 'Select the token to pay'
+    },
+    participantForm: {
+      title: 'Complete your participant profile',
+      description: 'Fill in your personal information so we can share the registration with the hosts.',
+      firstNameLabel: 'First name',
+      lastNameLabel: 'Last name',
+      idTypeLabel: 'Identification type',
+      idNumberLabel: 'Identification number',
+      accommodationLabel: 'Accommodation',
+      nationalityLabel: 'Nationality',
+      birthDateLabel: 'Birth date',
+      idTypeDni: 'DNI',
+      idTypePassport: 'Passport',
+      idTypeOther: 'Other',
+      cancelButton: 'Cancel',
+      saveButton: 'Save and continue',
+      requiredField: 'This field is required.'
     }
   },
   es: {
@@ -185,7 +203,8 @@ export const translations = {
       insufficientBalance: 'Tu balance de USDT no es suficiente para cubrir esta inscripción.',
       insufficientBalanceToken: 'Tu balance de {token} no es suficiente para cubrir esta inscripción.',
       usdtUnavailable: 'El token de USDT configurado ({address}) no está desplegado en {network}.',
-      tokenUnavailable: 'El token de {token} configurado ({address}) no está desplegado en {network}.'
+      tokenUnavailable: 'El token de {token} configurado ({address}) no está desplegado en {network}.',
+      missingParticipantInfo: 'Completá tu información personal antes de enviar el registro.'
 
     },
     alerts: {
@@ -208,6 +227,23 @@ export const translations = {
       participantCountHelper: 'Elegí cuántos lugares querés reservar.',
       transactionInfo: 'MetaMask enviará tu mensaje on-chain a {wallet}.',
       paymentTokenLabel: 'Seleccioná el token de pago'
+    },
+    participantForm: {
+      title: 'Completá tu perfil de participante',
+      description: 'Ingresá tus datos personales para compartir el registro con los anfitriones.',
+      firstNameLabel: 'Nombre',
+      lastNameLabel: 'Apellido',
+      idTypeLabel: 'Tipo de documento',
+      idNumberLabel: 'Número o código del documento',
+      accommodationLabel: 'Alojamiento',
+      nationalityLabel: 'Nacionalidad',
+      birthDateLabel: 'Fecha de nacimiento',
+      idTypeDni: 'DNI',
+      idTypePassport: 'Pasaporte',
+      idTypeOther: 'Otro',
+      cancelButton: 'Cancelar',
+      saveButton: 'Guardar y continuar',
+      requiredField: 'Este campo es obligatorio.'
     }
   },
   fr: {


### PR DESCRIPTION
## Summary
- prompt visitors to fill in participant profile details before connecting a wallet and persist their answers locally
- require profile data to register for activities and forward it alongside activity and participant counts
- add a reusable modal component and translation strings for the new form copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc7794d0a48333a98c7d1ffe10e144