### PR TITLE
Add warning banner for non-Ethereum networks

### DIFF
--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -82,6 +82,12 @@ export const translations = {
       tokenUnavailable: 'The configured {token} token ({address}) is not deployed on {network}.'
 
     },
+    networkWarning: {
+      title: 'Switch to Ethereum Mainnet',
+      description: 'You are connected to {network}. Switch to the Ethereum network to continue with registrations.',
+      unknownNetwork: 'an unknown network',
+      action: 'Switch to Ethereum'
+    },
     alerts: {
       metaMask: 'Install MetaMask to continue.'
     },
@@ -187,6 +193,12 @@ export const translations = {
       usdtUnavailable: 'El token de USDT configurado ({address}) no está desplegado en {network}.',
       tokenUnavailable: 'El token de {token} configurado ({address}) no está desplegado en {network}.'
 
+    },
+    networkWarning: {
+      title: 'Cambiá a la red de Ethereum',
+      description: 'Estás conectado a {network}. Cambiá a la red de Ethereum para continuar con los registros.',
+      unknownNetwork: 'una red desconocida',
+      action: 'Cambiar a Ethereum'
     },
     alerts: {
       metaMask: 'Instalá MetaMask para continuar.'


### PR DESCRIPTION
## Summary
- detect the connected chain ID to determine when the wallet is not on Ethereum mainnet
- show a warning banner with a MetaMask network switch action when the user is on another chain
- localize the banner copy in English and Spanish alongside the existing translations

## Testing
- npm run test --prefix frontend -- --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68dc7f8089c883339e675d0c3b28c5d6