### PR TITLE
Add profile icon to navbar for editing participant info

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -216,6 +216,11 @@ function App() {
     setPendingConnection(false);
   }, []);
 
+  const handleEditParticipantInfo = useCallback(() => {
+    setPendingConnection(false);
+    setIsParticipantModalOpen(true);
+  }, []);
+
   const handleParticipantSubmit = useCallback(
     values => {
       setParticipantInfo(values);
@@ -290,6 +295,8 @@ function App() {
         text={text.navbar}
         languageLabel={text.languageSelectorLabel}
         languageOptions={languageOptions}
+        hasParticipantInfo={Boolean(participantInfo)}
+        onEditParticipantInfo={handleEditParticipantInfo}
       />
       {isWrongNetwork && (
         <div className="bg-amber-100 border-b border-amber-200 text-amber-900">

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -1,6 +1,43 @@
 import React from 'react';
 
-function Navbar({ account, connect, disconnect, language, setLanguage, text, languageLabel, languageOptions }) {
+function Navbar({
+  account,
+  connect,
+  disconnect,
+  language,
+  setLanguage,
+  text,
+  languageLabel,
+  languageOptions,
+  hasParticipantInfo,
+  onEditParticipantInfo
+}) {
+  const profileButtonLabel = text?.editProfile || 'Edit personal information';
+  const profileButton =
+    hasParticipantInfo && typeof onEditParticipantInfo === 'function' ? (
+      <button
+        type="button"
+        onClick={onEditParticipantInfo}
+        className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-blue-200 text-blue-600 transition hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        aria-label={profileButtonLabel}
+        title={profileButtonLabel}
+      >
+        <svg
+          className="h-5 w-5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4z" />
+          <path d="M4 20c0-2.21 3.582-4 8-4s8 1.79 8 4" />
+        </svg>
+      </button>
+    ) : null;
+
   return (
     <nav className="bg-white/90 backdrop-blur shadow">
       <div className="max-w-5xl mx-auto px-4 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -28,14 +65,26 @@ function Navbar({ account, connect, disconnect, language, setLanguage, text, lan
               <span className="font-mono text-sm bg-gray-100 px-2 py-1 rounded">
                 {account.slice(0, 6)}...{account.slice(-4)}
               </span>
-              <button onClick={disconnect} className="px-3 py-1 rounded bg-red-500 text-white hover:bg-red-600">
+              <button
+                type="button"
+                onClick={disconnect}
+                className="px-3 py-1 rounded bg-red-500 text-white transition hover:bg-red-600"
+              >
                 {text.disconnect}
               </button>
+              {profileButton}
             </div>
           ) : (
-            <button onClick={connect} className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">
-              {text.connect}
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                onClick={connect}
+                className="px-4 py-2 rounded bg-blue-600 text-white transition hover:bg-blue-700"
+              >
+                {text.connect}
+              </button>
+              {profileButton}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -6,7 +6,8 @@ export const translations = {
       title: 'Edge City · Patagonia Experience',
       subtitle: 'An immersive nature experience with every registration confirmed on-chain through a single wallet message.',
       connect: 'Connect wallet',
-      disconnect: 'Disconnect'
+      disconnect: 'Disconnect',
+      editProfile: 'Edit personal information'
     },
     hero: {
       badge: 'NEW EDITION 2025 · SAN MARTIN DE LOS ANDES',
@@ -133,7 +134,8 @@ export const translations = {
       title: 'Edge City · Residencia Patagonia',
       subtitle: 'Una experiencia inmersiva en la naturaleza con confirmaciones on-chain enviadas desde tu wallet.',
       connect: 'Conectar wallet',
-      disconnect: 'Desconectar'
+      disconnect: 'Desconectar',
+      editProfile: 'Editar datos personales'
     },
     hero: {
       badge: 'Nueva edición 2025 · San Martín de los Andes',
@@ -261,7 +263,8 @@ export const translations = {
       title: 'Edge City · Résidence Patagonie',
       subtitle: 'Une expérience immersive dans la nature avec inscriptions et paiements sécurisés sur la blockchain.',
       connect: 'Connecter le wallet',
-      disconnect: 'Déconnecter'
+      disconnect: 'Déconnecter',
+      editProfile: 'Modifier les données personnelles'
     },
     hero: {
       badge: 'Nouvelle édition 2025 · San Martín de los Andes',
@@ -377,7 +380,8 @@ export const translations = {
       title: 'Edge City · Patagonien-Residenz',
       subtitle: 'Eine immersive Naturerfahrung mit Anmeldungen und Zahlungen, die on-chain abgesichert sind.',
       connect: 'Wallet verbinden',
-      disconnect: 'Trennen'
+      disconnect: 'Trennen',
+      editProfile: 'Persönliche Daten bearbeiten'
     },
     hero: {
       badge: 'Neue Ausgabe 2025 · San Martín de los Andes',
@@ -492,7 +496,8 @@ export const translations = {
       title: 'Edge City · 巴塔哥尼亚驻地',
       subtitle: '沉浸式自然体验，报名和付款全部通过区块链保障。',
       connect: '连接钱包',
-      disconnect: '断开连接'
+      disconnect: '断开连接',
+      editProfile: '编辑个人资料'
     },
     hero: {
       badge: '2025 年全新一季 · 圣马丁德洛斯安第斯',
@@ -608,7 +613,8 @@ export const translations = {
       title: 'Edge City · Резиденция в Патагонии',
       subtitle: 'Иммерсивный опыт в природе с регистрациями и платежами, защищёнными блокчейном.',
       connect: 'Подключить кошелёк',
-      disconnect: 'Отключить'
+      disconnect: 'Отключить',
+      editProfile: 'Редактировать данные'
     },
     hero: {
       badge: 'Новое издание 2025 · Сан-Мартин-де-лос-Андес',


### PR DESCRIPTION
## Summary
- display a profile icon next to the wallet actions once participant information is completed
- allow reopening the participant information modal from the navbar icon
- add localized labels for the new profile editing control in all supported languages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dca87ec3e48333a8b2fe4a8ce77589