### PR TITLE
Ensure MetaMask disconnection revokes permissions

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -263,9 +263,22 @@ function App() {
     [registrationEndpoint]
   );
 
-  const disconnect = () => {
+  const disconnect = useCallback(async () => {
     setAccount(null);
-  };
+
+    if (!hasProvider || !window.ethereum?.request) {
+      return;
+    }
+
+    try {
+      await window.ethereum.request({
+        method: 'wallet_revokePermissions',
+        params: [{ eth_accounts: {} }]
+      });
+    } catch (error) {
+      console.error('Failed to revoke wallet permissions', error);
+    }
+  }, [hasProvider]);
 
   const handleSwitchToEthereum = useCallback(async () => {
     if (!hasProvider || !window.ethereum?.request) {


### PR DESCRIPTION
## Summary
- revoke MetaMask permissions when disconnecting so the wallet fully detaches from the site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd51ca6dd48333af3343bf627ba7b7