### PR TITLE
Restore residency activities and update kids mountain school copy

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,6 +32,7 @@ function App() {
           ...localized,
           id: activity.id,
           images: activity.images ? activity.images.filter(Boolean) : [],
+          imageFolderCid: activity.imageFolderCid || null,
           priceUSDT: activity.priceUSDT,
           maxParticipants: activity.maxParticipants
         };
@@ -376,7 +377,11 @@ function App() {
 
             return (
               <article key={activity.id} className="overflow-hidden rounded-3xl bg-white shadow-lg ring-1 ring-slate-100">
-                <ActivityGallery images={activity.images} alt={activity.title} />
+                <ActivityGallery
+                  images={activity.images}
+                  alt={activity.title}
+                  folderCid={activity.imageFolderCid}
+                />
                 <div className="relative overflow-hidden px-6 py-6">
                   {isPatagonianAsado && (
                     <>

--- a/frontend/src/components/ActivityGallery.js
+++ b/frontend/src/components/ActivityGallery.js
@@ -1,8 +1,83 @@
 import { useEffect, useMemo, useState } from 'react';
 
-function ActivityGallery({ images = [], alt }) {
-  const gallery = useMemo(() => images.filter(Boolean), [images]);
+const resolveFolderImages = async (folderCid, signal) => {
+  const endpoint = `https://ipfs.io/api/v0/ls?arg=${encodeURIComponent(folderCid)}`;
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    signal,
+    headers: {
+      Accept: 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Unexpected status ${response.status}`);
+  }
+
+  const payload = await response.json();
+  const links = payload?.Objects?.[0]?.Links || [];
+
+  return links
+    .filter(link => link && typeof link.Hash === 'string' && link.Type !== 1)
+    .sort((a, b) => (a?.Name || '').localeCompare(b?.Name || ''))
+    .map(link => {
+      const base = `https://ipfs.io/ipfs/${link.Hash}`;
+      if (link?.Name) {
+        return `${base}?filename=${encodeURIComponent(link.Name)}`;
+      }
+      return base;
+    });
+};
+
+function ActivityGallery({ images = [], alt, folderCid }) {
   const [activeIndex, setActiveIndex] = useState(0);
+  const [folderImages, setFolderImages] = useState([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    if (!folderCid) {
+      setFolderImages([]);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    const controller = new AbortController();
+
+    const loadImages = async () => {
+      try {
+        const resolved = await resolveFolderImages(folderCid, controller.signal);
+        if (isMounted) {
+          setFolderImages(resolved);
+        }
+      } catch (error) {
+        if (error.name === 'AbortError') {
+          return;
+        }
+        console.error(`Failed to load images for IPFS directory ${folderCid}`, error);
+        if (isMounted) {
+          setFolderImages([]);
+        }
+      }
+    };
+
+    loadImages();
+
+    return () => {
+      isMounted = false;
+      controller.abort();
+    };
+  }, [folderCid]);
+
+  const baseImages = useMemo(() => images.filter(Boolean), [images]);
+  const gallery = useMemo(() => {
+    if (folderImages.length === 0) {
+      return baseImages;
+    }
+    const combined = [...baseImages, ...folderImages];
+    return Array.from(new Set(combined.filter(Boolean)));
+  }, [baseImages, folderImages]);
 
   useEffect(() => {
     if (gallery.length === 0) {

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -299,5 +299,94 @@ export const residencyActivities = [
         guide: 'Curaduría del equipo culinario de Edge City.'
       }
     }
+  },
+  {
+    id: 'mountain-expedition',
+    priceUSDT: 150,
+    maxParticipants: 40,
+    images: [],
+    imageFolderCid: 'bafybeih77q6wubddx6phljd6ajbcua7jooh2wnxbxz4c2rvna2tdrjzdha',
+    translations: {
+      en: {
+        title: 'Children’s mountain school in the heart of the Andes',
+        summary:
+          'An outdoor school for ages 5–16 with rotating kayak, mountain biking, trekking, nature living, orientation, and team sport modules. Every Sunday we share the weekly plan for two-and-a-half-hour sessions across the week plus a three-hour family outing on Saturdays. Sports and safety gear are provided and groups open from a minimum of 3 up to 40 participants.',
+        highlights: [
+          'Designed for children aged 5–16 with all sports and safety equipment included.',
+          'Rotating disciplines: kayak, mountain biking, trekking, nature living workshops, orientation circuits, and team sports.',
+          'Flexible plans: USD 150 for 2 sessions per week, USD 200 for 3 sessions, USD 270 for 4 sessions; Saturday family excursion at USD 60 per person.',
+          'Weekly schedule sent every Sunday with groups confirmed from 3 to 40 participants.'
+        ],
+        guide: 'Coordinated by the Edge City youth mountain guides.'
+      },
+      es: {
+        title: 'Escuela de montaña infantil en el corazón de la cordillera',
+        summary:
+          'Programa para infancias de 5 a 16 años con módulos rotativos de kayak, bici de montaña, trekking, vida en la naturaleza, orientación y deportes de conjunto. Cada domingo se envía el cronograma semanal de encuentros de dos horas y media, más una salida familiar de tres horas los sábados. Incluye equipamiento deportivo y de seguridad, con grupos que se arman desde un mínimo de 3 hasta un máximo de 40 participantes.',
+        highlights: [
+          'Pensada para infancias de 5 a 16 años con todo el equipamiento deportivo y de seguridad incluido.',
+          'Actividades rotativas: kayak, bici de montaña, trekking, vida en la naturaleza, circuitos de orientación y deportes de conjunto.',
+          'Planes flexibles: USD 150 por 2 encuentros semanales, USD 200 por 3 encuentros, USD 270 por 4 encuentros; excursión familiar del sábado a USD 60 por persona.',
+          'Cronograma enviado cada domingo con cupos habilitados desde 3 hasta 40 participantes.'
+        ],
+        guide: 'Coordinación del equipo de guías de montaña para infancias de Edge City.'
+      }
+    }
+  },
+  {
+    id: 'lake-kayak',
+    images: ['https://ipfs.io/ipfs/bafkreia6mqussojkw3tcngfj6iyow2gjszuxsjereznjomefa2iajg7x4q'],
+    translations: {
+      en: {
+        title: 'Kayak journey across Lake Lolog',
+        summary:
+          'A gentle paddle through transparent bays, learning Patagonian weather patterns and gliding silently at sunset.',
+        highlights: [
+          'Double kayaks, life vests, and safety briefing included.',
+          'On-chain check-in at embarkation with live tracking of spots.',
+          'Campfire toast on the volcanic-sand beach.'
+        ],
+        guide: 'Logistics with the Lolog nautical club and resident artists.'
+      },
+      es: {
+        title: 'Travesía en kayak por el lago Lolog',
+        summary:
+          'Remada suave entre bahías transparentes, aprendiendo lectura del clima patagónico y navegando en silencio al atardecer.',
+        highlights: [
+          'Kayaks dobles, chalecos y briefing de seguridad incluidos.',
+          'Check-in en cadena al embarcar y seguimiento de cupos en vivo.',
+          'Brindis con cocina de campamento en la playa de arena volcánica.'
+        ],
+        guide: 'Logística junto al club náutico de Lolog y artistas residentes.'
+      }
+    }
+  },
+  {
+    id: 'rock-climbing',
+    images: ['https://ipfs.io/ipfs/bafkreiazmgq5d4xq72ggid33nkh4fozsn6ek6feaf3oqes3mczybyjyqca'],
+    translations: {
+      en: {
+        title: 'Rock-climbing clinic and mindful movement',
+        summary:
+          'A progressive session at the local granite school to connect strength, breathing, and creative focus.',
+        highlights: [
+          'All levels welcome: from intro bouldering to roped routes.',
+          'Progress tracking and digital waiver recorded on-chain.',
+          'Integration circle with sound at the base of the wall.'
+        ],
+        guide: 'Mentored by IFMGA guides and Edge City performers.'
+      },
+      es: {
+        title: 'Clínica de escalada en roca y movimientos conscientes',
+        summary:
+          'Sesión progresiva en la escuela de granito local para conectar fuerza, respiración y foco creativo.',
+        highlights: [
+          'Todos los niveles: desde boulder introductorio a vías con cuerda.',
+          'Seguimiento de progresos y liberación de responsabilidad digital firmada on-chain.',
+          'Círculo de integración sonora al pie de la pared.'
+        ],
+        guide: 'Mentoreada por guías IFMGA y performers de Edge City.'
+      }
+    }
   }
 ];


### PR DESCRIPTION
## Summary
- restore the original residency activities alongside the updated children's mountain school details within the mountain expedition slot
- retain the IPFS-backed gallery support so the new school entry resolves the provided folder images

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd5ae31f308333b9039121e8cf8f7a