### PR TITLE
Add wallet-based user management backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 frontend/node_modules/
+backend/node_modules/
+**/.env

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ to the organizer's wallet—no smart contracts or escrow layers are involved.
 - Collect USDT payments that are sent immediately to the organizer's wallet.
 - Track real-time availability, registrations and participant wallets from the dashboard.
 - Offer a multilingual interface (English, Spanish and French) connected to the residency data.
+- Authenticate participants and organizers with their wallets and persist their profile data in
+  PostgreSQL.
 
 ## Payment flow
 
@@ -25,6 +27,7 @@ point at your deployment:
 
 - `REACT_APP_DESTINATION_WALLET`: wallet address that receives participant payments.
 - `REACT_APP_USDT_ADDRESS`: address of the ERC20 token accepted for payments.
+- `REACT_APP_REGISTRATION_ENDPOINT`: URL of the backend profile API.
 
 ## Hardcoded on-chain addresses
 
@@ -35,6 +38,50 @@ can copy the file into `.env` and override them when deploying elsewhere:
   (Hardhat default account #0 used for local testing).
 - **USDT token** (`REACT_APP_USDT_ADDRESS`): `0xdAC17F958D2ee523a2206206994597C13D831ec7` (Tether on
   Ethereum mainnet).
+
+## Backend API
+
+The `backend` folder exposes a lightweight Express server backed by Prisma and PostgreSQL 17. Wallet
+holders authenticate by signing a nonce-based challenge and can then persist profile information.
+
+### Environment variables
+
+Copy `backend/.env.example` to `backend/.env` and set at least the following variables:
+
+- `DATABASE_URL`: PostgreSQL connection string.
+- `PORT` (optional): API port, defaults to `4000`.
+- `CORS_ORIGIN` (optional): comma-separated origins allowed to call the API. Defaults to `*`.
+
+### Prisma setup
+
+Install dependencies and generate the Prisma client:
+
+```bash
+cd backend
+npm install
+npm run prisma:generate
+```
+
+Create and apply migrations before running the API (the command assumes an existing database):
+
+```bash
+npx prisma migrate dev --name init
+```
+
+### Available endpoints
+
+- `POST /auth/challenge` – creates or refreshes a login nonce for the supplied wallet address.
+- `POST /auth/verify` – validates a signature and rotates the nonce.
+- `GET /profile/:walletAddress` – fetches the persisted profile for a wallet.
+- `PUT /profile` – upserts profile metadata and optional custom fields.
+
+### Start the server
+
+```bash
+npm run dev
+# or
+npm start
+```
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ point at your deployment:
 
 - `REACT_APP_DESTINATION_WALLET`: wallet address that receives participant payments.
 - `REACT_APP_USDT_ADDRESS`: address of the ERC20 token accepted for payments.
-- `REACT_APP_REGISTRATION_ENDPOINT` (optional): URL of the backend profile API. If omitted, the
-  dashboard will call the same origin it was loaded from.
+- `NEXTAUTH_URL` (optional): URL of the backend profile API. If omitted, the dashboard will call the
+  same origin it was loaded from. The previous `REACT_APP_REGISTRATION_ENDPOINT` variable remains
+  supported for backwards compatibility.
 
 ## Hardcoded on-chain addresses
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ point at your deployment:
 
 - `REACT_APP_DESTINATION_WALLET`: wallet address that receives participant payments.
 - `REACT_APP_USDT_ADDRESS`: address of the ERC20 token accepted for payments.
-- `REACT_APP_REGISTRATION_ENDPOINT`: URL of the backend profile API.
+- `REACT_APP_REGISTRATION_ENDPOINT` (optional): URL of the backend profile API. If omitted, the
+  dashboard will call the same origin it was loaded from.
 
 ## Hardcoded on-chain addresses
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,6 @@
+# Database connection string for PostgreSQL 17
+# Format: postgresql://USER:PASSWORD@HOST:PORT/DATABASE?schema=public
+DATABASE_URL="postgresql://postgres:postgres@localhost:5432/edgecity?schema=public"
+
+# Optional: host and port for the Express API server
+PORT=4000

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "edgecity-backend",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node --watch ./src/server.js",
+    "start": "node ./src/server.js",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate deploy"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.13.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "ethers": "^6.10.0",
+    "express": "^4.18.3",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "prisma": "^5.13.0"
+  }
+}

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,33 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id            String   @id @default(cuid())
+  walletAddress String   @unique
+  displayName   String?  @db.VarChar(100)
+  email         String?  @unique
+  bio           String?  @db.VarChar(500)
+  avatarUrl     String?  @db.VarChar(500)
+  nonce         String   @db.VarChar(64)
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+  profiles      Profile[]
+}
+
+model Profile {
+  id          String   @id @default(cuid())
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId      String
+  field       String
+  value       String
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@unique([userId, field])
+}

--- a/backend/src/prismaClient.js
+++ b/backend/src/prismaClient.js
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis;
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -1,0 +1,112 @@
+import { Router } from 'express';
+import { randomBytes } from 'crypto';
+import { ethers } from 'ethers';
+import { z } from 'zod';
+
+import prisma from '../prismaClient.js';
+
+const router = Router();
+
+const walletSchema = z.object({
+  walletAddress: z
+    .string({ required_error: 'walletAddress is required' })
+    .transform(value => ethers.getAddress(value))
+});
+
+const verifySchema = z
+  .object({
+    walletAddress: z.string(),
+    signature: z.string({ required_error: 'signature is required' })
+  })
+  .superRefine((data, ctx) => {
+    try {
+      ethers.getAddress(data.walletAddress);
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['walletAddress'],
+        message: 'Invalid wallet address'
+      });
+    }
+  });
+
+const generateNonce = () => randomBytes(16).toString('hex');
+
+const buildMessage = nonce => `EdgeCity login verification: ${nonce}`;
+
+router.post('/challenge', async (req, res, next) => {
+  try {
+    const { walletAddress } = walletSchema.parse(req.body);
+    const nonce = generateNonce();
+    const user = await prisma.user.upsert({
+      where: { walletAddress },
+      create: {
+        walletAddress,
+        nonce
+      },
+      update: { nonce }
+    });
+
+    res.json({
+      message: buildMessage(user.nonce),
+      nonce: user.nonce,
+      user: {
+        id: user.id,
+        walletAddress: user.walletAddress,
+        displayName: user.displayName,
+        email: user.email,
+        bio: user.bio,
+        avatarUrl: user.avatarUrl
+      }
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post('/verify', async (req, res, next) => {
+  try {
+    const { walletAddress, signature } = verifySchema.parse(req.body);
+    const normalizedWallet = ethers.getAddress(walletAddress);
+
+    const user = await prisma.user.findUnique({
+      where: { walletAddress: normalizedWallet }
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: 'User not found for wallet address' });
+    }
+
+    const message = buildMessage(user.nonce);
+    let recovered;
+    try {
+      recovered = ethers.verifyMessage(message, signature);
+    } catch (error) {
+      return res.status(400).json({ error: 'Invalid signature' });
+    }
+
+    if (ethers.getAddress(recovered) !== normalizedWallet) {
+      return res.status(401).json({ error: 'Signature verification failed' });
+    }
+
+    const updated = await prisma.user.update({
+      where: { id: user.id },
+      data: { nonce: generateNonce() }
+    });
+
+    res.json({
+      user: {
+        id: updated.id,
+        walletAddress: updated.walletAddress,
+        displayName: updated.displayName,
+        email: updated.email,
+        bio: updated.bio,
+        avatarUrl: updated.avatarUrl
+      }
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/profile.js
+++ b/backend/src/routes/profile.js
@@ -1,0 +1,120 @@
+import { Router } from 'express';
+import { ethers } from 'ethers';
+import { z } from 'zod';
+
+import prisma from '../prismaClient.js';
+
+const router = Router();
+
+const profileSchema = z.object({
+  walletAddress: z
+    .string({ required_error: 'walletAddress is required' })
+    .transform(value => ethers.getAddress(value)),
+  displayName: z.string().trim().min(1).max(100).optional(),
+  email: z.string().email().optional(),
+  bio: z.string().max(500).optional(),
+  avatarUrl: z.string().url().optional(),
+  extraFields: z
+    .array(
+      z.object({
+        field: z.string().min(1),
+        value: z.string().min(1)
+      })
+    )
+    .optional()
+});
+
+router.get('/:walletAddress', async (req, res, next) => {
+  try {
+    const walletAddress = ethers.getAddress(req.params.walletAddress);
+    const user = await prisma.user.findUnique({
+      where: { walletAddress },
+      include: { profiles: true }
+    });
+
+    if (!user) {
+      return res.status(404).json({ error: 'Profile not found' });
+    }
+
+    res.json({
+      id: user.id,
+      walletAddress: user.walletAddress,
+      displayName: user.displayName,
+      email: user.email,
+      bio: user.bio,
+      avatarUrl: user.avatarUrl,
+      extraFields: user.profiles.map(profile => ({
+        field: profile.field,
+        value: profile.value
+      }))
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/', async (req, res, next) => {
+  try {
+    const { walletAddress, displayName, email, bio, avatarUrl, extraFields } =
+      profileSchema.parse(req.body);
+
+    const user = await prisma.user.findUnique({ where: { walletAddress } });
+
+    if (!user) {
+      return res.status(404).json({ error: 'User must authenticate before updating profile' });
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        displayName,
+        email,
+        bio,
+        avatarUrl,
+        profiles: {
+          upsert: (extraFields || []).map(field => ({
+            where: {
+              userId_field: {
+                userId: user.id,
+                field: field.field
+              }
+            },
+            create: {
+              field: field.field,
+              value: field.value
+            },
+            update: {
+              value: field.value
+            }
+          })),
+          deleteMany: extraFields
+            ? {
+                userId: user.id,
+                field: {
+                  notIn: extraFields.map(field => field.field)
+                }
+              }
+            : undefined
+        }
+      },
+      include: { profiles: true }
+    });
+
+    res.json({
+      id: updatedUser.id,
+      walletAddress: updatedUser.walletAddress,
+      displayName: updatedUser.displayName,
+      email: updatedUser.email,
+      bio: updatedUser.bio,
+      avatarUrl: updatedUser.avatarUrl,
+      extraFields: updatedUser.profiles.map(profile => ({
+        field: profile.field,
+        value: profile.value
+      }))
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,35 @@
+import 'dotenv/config';
+import express from 'express';
+import cors from 'cors';
+
+import authRoutes from './routes/auth.js';
+import profileRoutes from './routes/profile.js';
+
+const app = express();
+
+app.use(
+  cors({
+    origin: process.env.CORS_ORIGIN?.split(',').map(origin => origin.trim()) || '*'
+  })
+);
+app.use(express.json());
+
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok', timestamp: new Date().toISOString() });
+});
+
+app.use('/auth', authRoutes);
+app.use('/profile', profileRoutes);
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  if (err.name === 'ZodError') {
+    return res.status(400).json({ errors: err.errors });
+  }
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`EdgeCity API listening on port ${port}`);
+});

--- a/backend/src/utils/auth.js
+++ b/backend/src/utils/auth.js
@@ -1,0 +1,5 @@
+import { randomBytes } from 'crypto';
+
+export const generateNonce = () => randomBytes(16).toString('hex');
+
+export const buildAuthMessage = nonce => `EdgeCity login verification: ${nonce}`;

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -9,4 +9,4 @@ REACT_APP_USDT_ADDRESS=0xdAC17F958D2ee523a2206206994597C13D831ec7
 
 # Base URL of the registration/profile API (Express + Prisma backend).
 # Leave unset when the dashboard and API share the same origin.
-REACT_APP_REGISTRATION_ENDPOINT=http://localhost:4000
+NEXTAUTH_URL=http://localhost:4000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -6,3 +6,6 @@ REACT_APP_DESTINATION_WALLET=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 
 # Address of the ERC20 token (e.g., USDT) used for activity payments
 REACT_APP_USDT_ADDRESS=0xdAC17F958D2ee523a2206206994597C13D831ec7
+
+# Base URL of the registration/profile API (Express + Prisma backend)
+REACT_APP_REGISTRATION_ENDPOINT=http://localhost:4000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,5 +7,6 @@ REACT_APP_DESTINATION_WALLET=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 # Address of the ERC20 token (e.g., USDT) used for activity payments
 REACT_APP_USDT_ADDRESS=0xdAC17F958D2ee523a2206206994597C13D831ec7
 
-# Base URL of the registration/profile API (Express + Prisma backend)
+# Base URL of the registration/profile API (Express + Prisma backend).
+# Leave unset when the dashboard and API share the same origin.
 REACT_APP_REGISTRATION_ENDPOINT=http://localhost:4000

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -39,7 +39,8 @@ function App() {
   );
   const hasProvider = useMemo(() => typeof window !== 'undefined' && window.ethereum, []);
   const participantFormText = text?.participantForm || {};
-  const registrationEndpoint = process.env.REACT_APP_REGISTRATION_ENDPOINT;
+  const registrationEndpoint =
+    process.env.NEXTAUTH_URL || process.env.REACT_APP_REGISTRATION_ENDPOINT;
   const registrationApiBase = useMemo(() => {
     if (registrationEndpoint && registrationEndpoint.trim()) {
       return registrationEndpoint.replace(/\/+$/, '');

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -41,10 +41,15 @@ function App() {
   const participantFormText = text?.participantForm || {};
   const registrationEndpoint = process.env.REACT_APP_REGISTRATION_ENDPOINT;
   const registrationApiBase = useMemo(() => {
-    if (!registrationEndpoint) {
-      return null;
+    if (registrationEndpoint && registrationEndpoint.trim()) {
+      return registrationEndpoint.replace(/\/+$/, '');
     }
-    return registrationEndpoint.replace(/\/+$/, '');
+
+    if (typeof window !== 'undefined' && window.location?.origin) {
+      return window.location.origin.replace(/\/+$/, '');
+    }
+
+    return null;
   }, [registrationEndpoint]);
   const metaMaskAlert = text?.alerts?.metaMask || 'Install MetaMask to continue.';
   const wrongNetworkAlert = text?.alerts?.wrongNetwork;

--- a/frontend/src/translations.js
+++ b/frontend/src/translations.js
@@ -125,6 +125,8 @@ export const translations = {
       idTypeOther: 'Other',
       cancelButton: 'Cancel',
       saveButton: 'Save and continue',
+      savingButton: 'Saving...',
+      submitErrorMessage: 'We could not save your information. Please try again.',
       requiredField: 'This field is required.'
     }
   },
@@ -254,6 +256,8 @@ export const translations = {
       idTypeOther: 'Otro',
       cancelButton: 'Cancelar',
       saveButton: 'Guardar y continuar',
+      savingButton: 'Guardando...',
+      submitErrorMessage: 'No pudimos guardar tu información. Intentá nuevamente.',
       requiredField: 'Este campo es obligatorio.'
     }
   }


### PR DESCRIPTION
## Summary
- add a backend service with Express, Prisma, and PostgreSQL for wallet-authenticated user profiles
- define Prisma models for users and custom profile fields with nonce-based authentication helpers
- document backend setup, environment variables, and API usage in the README

## Testing
- npm test *(fails: Hardhat cannot download compiler list in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df1af8b49c83339367f5f2cb77a84a